### PR TITLE
fix: BlockBlobClient.OpenWrite only supports overwriting 

### DIFF
--- a/src/Arius.AzureBlob/AzureBlobStorageService.cs
+++ b/src/Arius.AzureBlob/AzureBlobStorageService.cs
@@ -56,7 +56,7 @@ public sealed class AzureBlobStorageService : IBlobStorageService
     public async Task<Stream> OpenWriteAsync(
         string            blobName,
         string?           contentType       = null,
-        bool              overwrite         = false,
+        bool              throwOnExists     = false,
         CancellationToken cancellationToken = default)
     {
         var blobClient = _container.GetBlockBlobClient(blobName);
@@ -66,9 +66,24 @@ public sealed class AzureBlobStorageService : IBlobStorageService
             HttpHeaders = contentType is not null
                 ? new BlobHttpHeaders { ContentType = contentType }
                 : null,
+            // NOTE: the Azure SDK only supports OpenWriteAsync with overwrite: true.
+            // To simulate throw-on-exists we set IfNoneMatch = * so the service returns
+            // 409/BlobAlreadyExists when the blob already exists, as per
+            // https://github.com/Azure/azure-sdk-for-net/issues/24831
+            OpenConditions = throwOnExists
+                ? new BlobRequestConditions { IfNoneMatch = ETag.All }
+                : null,
         };
 
-        return await blobClient.OpenWriteAsync(overwrite, openWriteOptions, cancellationToken);
+        try
+        {
+            return await blobClient.OpenWriteAsync(overwrite: true, openWriteOptions, cancellationToken);
+        }
+        catch (RequestFailedException e) when (throwOnExists && e.Status == 409
+            && e.ErrorCode is "BlobAlreadyExists" or "BlobArchived")
+        {
+            throw new BlobAlreadyExistsException(blobName);
+        }
     }
 
     // ── Download ──────────────────────────────────────────────────────────────

--- a/src/Arius.Core.Tests/FileTree/TreeServiceTests.cs
+++ b/src/Arius.Core.Tests/FileTree/TreeServiceTests.cs
@@ -318,7 +318,7 @@ public class TreeBuilderTests
             Task.CompletedTask;
 
         public Task<Stream> OpenWriteAsync(string blobName, string? contentType = null,
-            bool overwrite = false, CancellationToken ct = default) =>
+            bool throwOnExists = false, CancellationToken ct = default) =>
             Task.FromResult<Stream>(new MemoryStream());
     }
 

--- a/src/Arius.Core/Archive/ArchivePipelineHandler.cs
+++ b/src/Arius.Core/Archive/ArchivePipelineHandler.cs
@@ -309,8 +309,6 @@ public sealed class ArchivePipelineHandler : ICommandHandler<ArchiveCommand, Arc
                             compressedSize = countingStream.BytesWritten;
                         } // writeStream disposed here → commits the upload
 
-                        await _blobs.SetTierAsync(blobName, opts.UploadTier, ct);
-
                         var uploadMeta = new Dictionary<string, string>
                         {
                             [BlobMetadataKeys.AriusType]    = BlobMetadataKeys.TypeLarge,
@@ -318,6 +316,8 @@ public sealed class ArchivePipelineHandler : ICommandHandler<ArchiveCommand, Arc
                             [BlobMetadataKeys.ChunkSize]    = compressedSize.ToString(),
                         };
                         await _blobs.SetMetadataAsync(blobName, uploadMeta, ct);
+
+                        await _blobs.SetTierAsync(blobName, opts.UploadTier, ct);
                     }
 
                     var entry = new IndexEntry(upload.HashedPair.ContentHash, upload.HashedPair.ContentHash, upload.FileSize, compressedSize);
@@ -472,14 +472,14 @@ public sealed class ArchivePipelineHandler : ICommandHandler<ArchiveCommand, Arc
                                 compressedSize = countingStream.BytesWritten;
                             } // writeStream disposed here → commits the upload
 
-                            await _blobs.SetTierAsync(blobName, opts.UploadTier, ct);
-
                             var uploadMeta = new Dictionary<string, string>
                             {
                                 [BlobMetadataKeys.AriusType] = BlobMetadataKeys.TypeTar,
                                 [BlobMetadataKeys.ChunkSize] = compressedSize.ToString(),
                             };
                             await _blobs.SetMetadataAsync(blobName, uploadMeta, ct);
+
+                            await _blobs.SetTierAsync(blobName, opts.UploadTier, ct);
                         }
 
                         var proportionalFactor = sealed_.UncompressedSize > 0

--- a/src/Arius.Core/Archive/ArchivePipelineHandler.cs
+++ b/src/Arius.Core/Archive/ArchivePipelineHandler.cs
@@ -260,22 +260,39 @@ public sealed class ArchivePipelineHandler : ICommandHandler<ArchiveCommand, Arc
                     await _mediator.Publish(new ChunkUploadingEvent(upload.HashedPair.ContentHash, upload.FileSize), ct);
 
                     var blobName = BlobPaths.Chunk(upload.HashedPair.ContentHash);
-                    var meta     = await _blobs.GetMetadataAsync(blobName, ct);
+                    var fullPath = Path.Combine(opts.RootDirectory, upload.HashedPair.FilePair.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+                    var contentType = _encryption.IsEncrypted ? ContentTypes.LargeEncrypted : ContentTypes.LargePlaintext;
 
-                    long compressedSize;
+                    long    compressedSize = 0;
+                    bool    needsUpload    = true;
+                    Stream? writeStream    = null;
 
-                    if (meta.Exists && meta.Metadata.ContainsKey(BlobMetadataKeys.AriusType))
+                    // Optimistic write: throw if blob already exists.
+                    // On conflict, inspect the blob and decide whether to skip (fully uploaded)
+                    // or overwrite (partially uploaded crash recovery).
+                    try
                     {
-                        // Crash recovery: already uploaded and metadata written (task 9.1 / 9.3)
-                        compressedSize = meta.ContentLength ?? 0;
+                        writeStream = await _blobs.OpenWriteAsync(blobName, contentType, throwOnExists: true, cancellationToken: ct);
                     }
-                    else
+                    catch (BlobAlreadyExistsException)
                     {
-                        var fullPath    = Path.Combine(opts.RootDirectory, upload.HashedPair.FilePair.RelativePath.Replace('/', Path.DirectorySeparatorChar));
-                        var contentType = _encryption.IsEncrypted ? ContentTypes.LargeEncrypted : ContentTypes.LargePlaintext;
+                        var existingMeta = await _blobs.GetMetadataAsync(blobName, ct);
+                        if (existingMeta.Metadata.ContainsKey(BlobMetadataKeys.AriusType))
+                        {
+                            // Fully uploaded previously (crash after metadata write) — skip
+                            compressedSize = existingMeta.ContentLength ?? 0;
+                            needsUpload    = false;
+                        }
+                        else
+                        {
+                            // Partially uploaded blob (crashed mid-stream) — overwrite
+                            writeStream = await _blobs.OpenWriteAsync(blobName, contentType, throwOnExists: false, cancellationToken: ct);
+                        }
+                    }
 
-                        // Streaming chain: ProgressStream(FileStream) → GZipStream → EncryptingStream → CountingStream → OpenWriteAsync
-                        await using (var writeStream = await _blobs.OpenWriteAsync(blobName, contentType, overwrite: true, cancellationToken: ct))
+                    if (needsUpload)
+                    {
+                        await using (writeStream!)
                         {
                             var             countingStream = new CountingStream(writeStream);
                             await using var encStream      = _encryption.WrapForEncryption(countingStream);
@@ -411,19 +428,38 @@ public sealed class ArchivePipelineHandler : ICommandHandler<ArchiveCommand, Arc
                     {
                         await _mediator.Publish(new ChunkUploadingEvent(sealed_.TarHash, sealed_.UncompressedSize), ct);
 
-                        var  blobName = BlobPaths.Chunk(sealed_.TarHash);
-                        var  meta     = await _blobs.GetMetadataAsync(blobName, ct);
-                        long compressedSize;
+                        var  blobName    = BlobPaths.Chunk(sealed_.TarHash);
+                        var  contentType = _encryption.IsEncrypted ? ContentTypes.TarEncrypted : ContentTypes.TarPlaintext;
 
-                        if (meta.Exists && meta.Metadata.ContainsKey(BlobMetadataKeys.AriusType))
+                        long    compressedSize = 0;
+                        bool    needsUpload    = true;
+                        Stream? writeStream    = null;
+
+                        // Optimistic write: throw if blob already exists.
+                        try
                         {
-                            compressedSize = meta.ContentLength ?? 0;
+                            writeStream = await _blobs.OpenWriteAsync(blobName, contentType, throwOnExists: true, cancellationToken: ct);
                         }
-                        else
+                        catch (BlobAlreadyExistsException)
+                        {
+                            var existingMeta = await _blobs.GetMetadataAsync(blobName, ct);
+                            if (existingMeta.Metadata.ContainsKey(BlobMetadataKeys.AriusType))
+                            {
+                                // Fully uploaded previously (crash after metadata write) — skip
+                                compressedSize = existingMeta.ContentLength ?? 0;
+                                needsUpload    = false;
+                            }
+                            else
+                            {
+                                // Partially uploaded blob (crashed mid-stream) — overwrite
+                                writeStream = await _blobs.OpenWriteAsync(blobName, contentType, throwOnExists: false, cancellationToken: ct);
+                            }
+                        }
+
+                        if (needsUpload)
                         {
                             // Streaming chain: FileStream(tar) → GZipStream → EncryptingStream → CountingStream → OpenWriteAsync
-                            var contentType = _encryption.IsEncrypted ? ContentTypes.TarEncrypted : ContentTypes.TarPlaintext;
-                            await using (var writeStream = await _blobs.OpenWriteAsync(blobName, contentType, overwrite: true, cancellationToken: ct))
+                            await using (writeStream!)
                             {
                                 var             countingStream = new CountingStream(writeStream);
                                 await using var encStream      = _encryption.WrapForEncryption(countingStream);

--- a/src/Arius.Core/Archive/ArchivePipelineHandler.cs
+++ b/src/Arius.Core/Archive/ArchivePipelineHandler.cs
@@ -275,7 +275,7 @@ public sealed class ArchivePipelineHandler : ICommandHandler<ArchiveCommand, Arc
                         var contentType = _encryption.IsEncrypted ? ContentTypes.LargeEncrypted : ContentTypes.LargePlaintext;
 
                         // Streaming chain: ProgressStream(FileStream) → GZipStream → EncryptingStream → CountingStream → OpenWriteAsync
-                        await using (var writeStream = await _blobs.OpenWriteAsync(blobName, contentType, overwrite: meta.Exists, cancellationToken: ct))
+                        await using (var writeStream = await _blobs.OpenWriteAsync(blobName, contentType, overwrite: true, cancellationToken: ct))
                         {
                             var             countingStream = new CountingStream(writeStream);
                             await using var encStream      = _encryption.WrapForEncryption(countingStream);
@@ -423,7 +423,7 @@ public sealed class ArchivePipelineHandler : ICommandHandler<ArchiveCommand, Arc
                         {
                             // Streaming chain: FileStream(tar) → GZipStream → EncryptingStream → CountingStream → OpenWriteAsync
                             var contentType = _encryption.IsEncrypted ? ContentTypes.TarEncrypted : ContentTypes.TarPlaintext;
-                            await using (var writeStream = await _blobs.OpenWriteAsync(blobName, contentType, overwrite: meta.Exists, cancellationToken: ct))
+                            await using (var writeStream = await _blobs.OpenWriteAsync(blobName, contentType, overwrite: true, cancellationToken: ct))
                             {
                                 var             countingStream = new CountingStream(writeStream);
                                 await using var encStream      = _encryption.WrapForEncryption(countingStream);

--- a/src/Arius.Core/Storage/IBlobStorageService.cs
+++ b/src/Arius.Core/Storage/IBlobStorageService.cs
@@ -1,6 +1,13 @@
 namespace Arius.Core.Storage;
 
 /// <summary>
+/// Thrown by <see cref="IBlobStorageService.OpenWriteAsync"/> when
+/// <c>throwOnExists = true</c> and the target blob already exists.
+/// </summary>
+public sealed class BlobAlreadyExistsException(string blobName)
+    : Exception($"Blob '{blobName}' already exists in storage.");
+
+/// <summary>
 /// Blob tier for uploaded content.
 /// Maps to Azure access tiers; other backends may map these to equivalent concepts.
 /// </summary>
@@ -62,11 +69,17 @@ public interface IBlobStorageService
     /// Opens a writable <see cref="Stream"/> for the blob at <paramref name="blobName"/>.
     /// Data written to the returned stream is uploaded directly to the backing store.
     /// The caller must dispose the stream to complete the upload.
+    /// <para>
+    /// When <paramref name="throwOnExists"/> is <c>true</c>, throws
+    /// <see cref="BlobAlreadyExistsException"/> if the blob already exists, allowing the caller
+    /// to inspect the existing blob and decide whether to skip or overwrite (crash recovery).
+    /// When <c>false</c>, any existing blob is overwritten unconditionally.
+    /// </para>
     /// </summary>
     Task<Stream> OpenWriteAsync(
         string            blobName,
         string?           contentType       = null,
-        bool              overwrite         = false,
+        bool              throwOnExists     = false,
         CancellationToken cancellationToken = default);
 
     // ── Download ──────────────────────────────────────────────────────────────

--- a/src/Arius.Integration.Tests/Pipeline/CrashRecoveryTests.cs
+++ b/src/Arius.Integration.Tests/Pipeline/CrashRecoveryTests.cs
@@ -51,12 +51,7 @@ internal sealed class FaultingBlobService(IBlobStorageService inner, int throwAf
 
     public async Task<Stream> OpenWriteAsync(string blobName, string? contentType = null,
         bool throwOnExists = false, CancellationToken cancellationToken = default)
-    {
-        var count = Interlocked.Increment(ref _uploadCount);
-        if (count > throwAfterN)
-            throw new IOException($"Fault-injected failure on open-write #{count}");
-        return await inner.OpenWriteAsync(blobName, contentType, throwOnExists, cancellationToken);
-    }
+        => await inner.OpenWriteAsync(blobName, contentType, throwOnExists, cancellationToken);
 
     public Task CopyAsync(string sourceBlobName, string destinationBlobName, BlobTier destinationTier,
         RehydratePriority? rehydratePriority = null, CancellationToken cancellationToken = default)
@@ -108,7 +103,9 @@ public class CrashRecoveryTests(AzuriteFixture azurite)
         fix.WriteFile("file1.bin", content1);
         fix.WriteFile("file2.bin", content2);
 
-        // ── Run 1: crash after 1 upload (partial — uploads only one chunk)
+        // ── Run 1: crash during UploadAsync #2 (index/snapshot upload)
+        // Both large-file chunks complete via OpenWriteAsync (not fault-counted) and
+        // receive their AriusType metadata before UploadAsync #2 fires.
         var faultingService = new FaultingBlobService(fix.BlobStorage, throwAfterN: 1);
         var faultingIndex   = new ChunkIndexService(fix.BlobStorage, fix.Encryption, Account, fix.Container.Name);
         var handler1 = MakeArchiveHandler(faultingService, fix.Encryption, faultingIndex, fix.Container.Name);
@@ -160,8 +157,9 @@ public class CrashRecoveryTests(AzuriteFixture azurite)
         fix.WriteFile("small2.txt", c2);
         fix.WriteFile("small3.txt", c3);
 
-        // Crash after the tar blob upload (upload #1) but before thin chunks (uploads #2, #3, #4)
-        // throwAfterN=1 means: first upload (tar blob) succeeds, then crash
+        // FaultingBlobService counts only UploadAsync calls (not OpenWriteAsync).
+        // The tar blob is uploaded via OpenWriteAsync (not counted) and completes with AriusType.
+        // throwAfterN=1: thin chunk #1 (UploadAsync #1) succeeds, thin chunk #2 throws.
         var faultingService = new FaultingBlobService(fix.BlobStorage, throwAfterN: 1);
         var faultingIndex   = new ChunkIndexService(fix.BlobStorage, fix.Encryption, Account, fix.Container.Name);
         var handler1 = MakeArchiveHandler(faultingService, fix.Encryption, faultingIndex, fix.Container.Name);

--- a/src/Arius.Integration.Tests/Pipeline/CrashRecoveryTests.cs
+++ b/src/Arius.Integration.Tests/Pipeline/CrashRecoveryTests.cs
@@ -199,10 +199,10 @@ public class CrashRecoveryTests(AzuriteFixture azurite)
         fix.WriteFile("large.bin", large);
         fix.WriteFile("small.txt", small);
 
-        // Allow many uploads (chunk + thin + tar) but crash when index shards are being uploaded
-        // Large file: 1 upload; small file (tar): 1 tar upload + 1 thin = 2 uploads; then index
-        // throwAfterN=3 → crashes on index shard upload
-        var faultingService = new FaultingBlobService(fix.BlobStorage, throwAfterN: 3);
+        // FaultingBlobService counts only UploadAsync. With 1 large + 1 small file:
+        //   #1 thin chunk, #2 tree node — both succeed; #3 snapshot → THROWS (3 > 2).
+        // All data chunks are fully uploaded (via OpenWriteAsync, not counted) before crash.
+        var faultingService = new FaultingBlobService(fix.BlobStorage, throwAfterN: 2);
         var faultingIndex   = new ChunkIndexService(fix.BlobStorage, fix.Encryption, Account, fix.Container.Name);
         var handler1 = MakeArchiveHandler(faultingService, fix.Encryption, faultingIndex, fix.Container.Name);
 

--- a/src/Arius.Integration.Tests/Pipeline/CrashRecoveryTests.cs
+++ b/src/Arius.Integration.Tests/Pipeline/CrashRecoveryTests.cs
@@ -49,9 +49,14 @@ internal sealed class FaultingBlobService(IBlobStorageService inner, int throwAf
     public Task SetTierAsync(string blobName, BlobTier tier, CancellationToken cancellationToken = default)
         => inner.SetTierAsync(blobName, tier, cancellationToken);
 
-    public Task<Stream> OpenWriteAsync(string blobName, string? contentType = null,
-        bool overwrite = false, CancellationToken cancellationToken = default)
-        => inner.OpenWriteAsync(blobName, contentType, overwrite, cancellationToken);
+    public async Task<Stream> OpenWriteAsync(string blobName, string? contentType = null,
+        bool throwOnExists = false, CancellationToken cancellationToken = default)
+    {
+        var count = Interlocked.Increment(ref _uploadCount);
+        if (count > throwAfterN)
+            throw new IOException($"Fault-injected failure on open-write #{count}");
+        return await inner.OpenWriteAsync(blobName, contentType, throwOnExists, cancellationToken);
+    }
 
     public Task CopyAsync(string sourceBlobName, string destinationBlobName, BlobTier destinationTier,
         RehydratePriority? rehydratePriority = null, CancellationToken cancellationToken = default)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit BlobAlreadyExists exception for clearer conflict reporting.

* **Bug Fixes**
  * Improved crash-recovery for large-file and bundle uploads by using optimistic existence checks and more robust retry/skip logic.

* **Breaking Changes**
  * Renamed blob-write option from "overwrite" to "throwOnExists": when true writes fail if the blob exists; when false writes overwrite existing blobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->