### PR TITLE
feat: parallelize archive finalization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,13 @@
 
 - Always update `README.md` (for humans) and `AGENTS.md` (for AI coding agents) to reflect the current state of the project
 
+## Durability And Scale
+
+- Arius is a backup/archive tool. Prefer recoverability and correctness over throughput.
+- Snapshot creation is the only repository commit point. Chunk-index flushes and filetree uploads that complete before a snapshot exists are tentative partial state, not a completed archive.
+- Parallelize independent work when useful, but do not weaken crash recovery semantics to do it.
+- When local cache publication depends on remote durability, prefer a spool-then-publish flow: write tentative data outside the final cache path, upload it, then publish the final cache entry only after upload succeeds.
+
 ## Testing
 
 This project uses **TUnit** (not xUnit/NUnit). Key differences:
@@ -48,8 +55,9 @@ This project uses **TUnit** (not xUnit/NUnit). Key differences:
   - **thin chunk**: a small pointer-like chunk blob whose body is the hash of the tar chunk that actually contains the file bytes. Why: as deduplication existence check and metadata.
 - **chunk index**: the repository-wide mapping from content hash to chunk hash. Why: 1/ TAR lookups 2/ efficient existence checks for deduplicated content and 3/ metadata store.
   - **shard**: one mutable chunk-index blob, partitioned by hash prefix for storage and caching.
+- **archive manifest**: the temporary per-run file-entry list written during archive, then externally sorted and consumed by `FileTreeBuilder`. It is not a durable repository commit object.
 - **filetree**: an immutable Merkle-tree blob describing one directory's entries. Filetrees model repository structure, not chunk storage.
-- **snapshot**: an immutable point-in-time manifest that records the root filetree hash and repository totals.
+- **snapshot**: an immutable point-in-time manifest that records the root filetree hash and repository totals. Snapshot creation is the repository commit point.
 
 - Prefer these terms consistently in code, tests, docs, and reviews. Avoid using generic words like "blob" or "pointer" when the more precise domain term is known.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ dotnet user-secrets set "arius:<account>:key" "<key>"
 Most test projects can be run directly with `dotnet test --project <path-to-csproj>`.
 `src/Arius.E2E.Tests` also requires `ARIUS_E2E_ACCOUNT` and `ARIUS_E2E_KEY` to be set; otherwise the suite fails immediately with a configuration error.
 
+## Archive Finalization
+
+Archive writes a temporary `archive manifest` on disk, externally sorts it, builds/uploads
+filetrees, flushes chunk-index shards, and only then creates the snapshot.
+
+Chunk-index flush and filetree upload now run in parallel during finalization, but snapshot
+creation is still the only repository commit point. If a run crashes after some shard or
+filetree uploads but before the snapshot is written, that work is treated as incomplete
+state rather than a completed archive.
+
+To keep the domain language precise, use `archive manifest` for the temporary tree-build
+input file and `snapshot` or `snapshot manifest` for the durable repository state stored
+under `snapshots/`.
+
 ## Updating
 
 Run:

--- a/openspec/changes/chunk-index-prefix-strategy/.openspec.yaml
+++ b/openspec/changes/chunk-index-prefix-strategy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/chunk-index-prefix-strategy/proposal.md
+++ b/openspec/changes/chunk-index-prefix-strategy/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The chunk-index shard prefix is currently hardcoded to 4 hex characters. That may not remain the best tradeoff as repositories scale: a shorter fixed prefix such as 3 hex characters could reduce the number of shard blobs, while a longer fixed prefix or a dynamic prefix policy could limit shard growth and hot-spotting. This question is larger than a simple performance tweak because shard-prefix strategy affects repository layout, cache behavior, and recovery semantics.
+
+Chunk-index writes are not transactional across blobs. A run can upload some shard blobs and not others, another machine can extend overlapping prefixes concurrently, and local L1/L2 caches can observe mixed old/new state. Any future prefix strategy work therefore needs to treat durability and recoverability as first-class concerns, not just shard-count optimization.
+
+## What Changes
+
+- **Generalize prefix strategy**: replace the implicit "always 4 hex chars" assumption with an explicit chunk-index prefix strategy that can later be implemented as either a fixed length (for example always 3 or always 4 chars) or a dynamic prefix-length policy.
+- **Explore tradeoffs before implementation**: compare fixed and dynamic strategies across shard count, shard size, lookup cost, flush cost, cache pressure, and operational simplicity.
+- **Define durability and recoverability rules**: specify what correctness means under partial flushes, crashes, concurrent writers, cache invalidation, and mixed local/remote state while blob storage remains non-transactional across shard blobs.
+- **Decide repository contract**: determine whether the chosen prefix strategy is repository metadata, configuration, a versioned format decision, or a deterministic algorithm derived from repository state.
+- **Plan rollout and recovery**: define how caches and remote layout transitions are detected, invalidated, recovered, or migrated before any prefix change ships.
+- **Require recovery proof**: add an integration test that deletes or corrupts the local and remote chunk-index state for a repository and proves Arius can rebuild a correct chunk-index view from scratch rather than depending on intact shard state.
+
+## Non-goals
+
+- Changing shard prefix length as part of `parallel-flush-and-tree-upload`.
+- Choosing a final prefix strategy in this proposal without the durability and recoverability model.
+
+## Capabilities
+
+### New Capabilities
+- `chunk-index-prefix-strategy`: Explicit repository rules for chunk-index shard partitioning, including future support for fixed or dynamic prefix length strategies.
+
+### Modified Capabilities
+- `blob-storage`: Chunk-index shard layout becomes a governed repository concern rather than an unexamined hardcoded constant.
+- `archive-pipeline`: Future flush and lookup behavior may depend on the repository's declared chunk-index prefix strategy.
+
+## Impact
+
+- **Storage contract**: future implementation may affect `chunk-index/` naming, cache layout, or repository metadata.
+- **Correctness work first**: durability, recoverability, mixed-state handling, and a recovery-from-scratch test are explicit design constraints for the follow-up phase.
+- **Separation of concerns**: finalization parallelism can proceed now without blocking on a shard-layout decision.

--- a/openspec/changes/parallel-flush-and-tree-upload/design.md
+++ b/openspec/changes/parallel-flush-and-tree-upload/design.md
@@ -1,0 +1,173 @@
+## Context
+
+The archive pipeline already uses substantial parallelism for hashing and chunk upload, but the finalization tail is still largely serialized. After upload work completes, `ArchiveCommandHandler` currently does the following in order:
+
+1. `FileTreeService.ValidateAsync()`
+2. `ChunkIndexService.FlushAsync()`
+3. `ManifestSorter.SortAsync()`
+4. `FileTreeBuilder.BuildAsync()`
+5. `SnapshotService.CreateAsync()`
+
+This shape leaves two distinct sources of end-of-pipeline latency:
+
+- `ChunkIndexService.FlushAsync()` flushes touched shard prefixes one at a time.
+- `FileTreeBuilder.BuildAsync()` computes tree blobs bottom-up and uploads each missing tree immediately, so upload latency is paid inline during tree construction.
+
+The codebase has evolved since this idea was first proposed. `FileTreeBuilder.BuildAsync()` now calls `FileTreeService.ValidateAsync()` itself before `ExistsInRemote()`, which means the validation precondition already lives inside the tree-building boundary. The old proposal also bundled shard-prefix changes, but shard layout is a separate repository-contract problem and is out of scope here.
+
+The design also has to respect Arius's scale and durability constraints. Arius is a backup tool for important files. Repositories may be large in total bytes and still contain many thousands of small files, so file-count scale matters as much as byte scale for archive, restore, and list operations. Blob storage is non-transactional across blobs, mutable caches can be stale or corrupt, and partial updates are unavoidable in crash scenarios. Finalization work therefore must stay recoverable, retry-safe, and clearly separated from the repository commit point.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reduce archive end-of-pipeline wall-clock time without changing repository layout.
+- Keep one clear owner for filetree validation.
+- Allow chunk-index flush to use parallel workers across independent shard prefixes.
+- Split tree building into a local hash-computation phase and a parallel upload phase without requiring unbounded memory.
+- Emit explicit progress events for finalization so the CLI shows useful progress after uploads finish.
+- Preserve durability semantics: snapshot creation remains the only repository commit point, and pre-snapshot work must be recoverable after interruption.
+
+**Non-Goals:**
+- Changing chunk-index shard prefix length, shard naming, or repository metadata.
+- Solving durability/recoverability for alternative shard-prefix strategies.
+- Reworking the manifest sort algorithm beyond fitting it into the new orchestration shape.
+- Moving archive orchestration out of `ArchiveCommandHandler` into Shared.
+
+## Decisions
+
+### Decision 1: `FileTreeBuilder` remains the validation owner
+
+`FileTreeBuilder.BuildAsync()` will remain responsible for ensuring `FileTreeService.ValidateAsync()` has run before any call to `ExistsInRemote()`.
+
+That means `ArchiveCommandHandler` will stop doing a redundant explicit pre-validation call. The builder already owns the precondition for tree existence checks, and keeping validation ownership there avoids splitting one invariant across two layers.
+
+Alternative considered: keep validation in `ArchiveCommandHandler` and remove it from `FileTreeBuilder`.
+Rejected because it makes `FileTreeBuilder` easier to misuse outside the archive handler and weakens the service boundary that has already emerged.
+
+### Decision 2: Tree building becomes a two-phase operation
+
+`FileTreeBuilder.BuildAsync()` will be refactored into a bounded producer/consumer pipeline:
+
+1. Validate once.
+2. Read the sorted manifest.
+3. Build directory entry sets and compute tree hashes bottom-up without remote I/O.
+4. For each computed tree hash, use `ExistsInRemote()` to decide whether upload is needed.
+5. For trees that need upload, serialize plaintext bytes to a temporary spool file outside the final cache directory and enqueue a descriptor into a bounded channel.
+6. Parallel upload workers consume descriptors, upload the tree blob, then publish the plaintext bytes into the final filetree cache path only after upload succeeds.
+7. Return the root tree hash after upload completion.
+
+The important observation is that parent directory hashes depend on child directory hashes, not on child uploads. Tree upload is therefore a persistence concern, not a computation dependency.
+
+The temporary spool file is important for both memory pressure and correctness:
+
+- It avoids holding all computed `FileTreeBlob` instances in memory when the repository has many directories.
+- It allows compute and upload to overlap.
+- It avoids publishing a final cache file before remote upload is known to have succeeded. Temp spool files are tentative local state; final filetree cache files represent confirmed remote existence.
+
+Alternative considered: keep the current inline `EnsureUploadedAsync()` call during bottom-up traversal and only parallelize the upload call itself.
+Rejected because the current structure still serializes existence checks and remote upload latency into the tree computation loop.
+
+Alternative considered: compute all trees in memory first, then upload from memory.
+Rejected because file-count scale can be large even when tree blobs are individually small; bounded disk-backed spooling is a better fit for Arius's scale assumptions.
+
+### Decision 3: `ChunkIndexService.FlushAsync()` parallelizes by shard prefix
+
+Flush workers will operate independently per touched shard prefix:
+
+`load existing shard -> merge pending entries for prefix -> serialize -> upload -> save L2 -> promote L1`
+
+The concurrency unit is one prefix. Prefixes are independent because each worker writes a distinct `chunk-index/<prefix>` blob and a distinct L2 file.
+
+Shared mutable state inside `ChunkIndexService` is limited to:
+
+- draining and grouping pending entries before worker launch
+- L1 cache promotion under the existing lock
+- progress counters
+
+Alternative considered: overlapping shard upload work while retaining sequential load/merge.
+Rejected because most of the per-prefix latency is in the whole end-to-end prefix pipeline, not just the final upload call.
+
+### Decision 4: Archive finalization overlaps only across real dependency boundaries
+
+The new orchestration is not "everything parallel with everything." The dependency graph is:
+
+```text
+flush ----------------------------\
+                                   -> snapshot
+sort -> compute tree hashes -> upload /
+```
+
+So the archive handler will overlap:
+
+- chunk-index flush branch
+- manifest sort + tree branch
+
+`SnapshotService.CreateAsync()` still waits until both branches are complete.
+
+Alternative considered: keep the archive handler fully sequential and rely only on internal service-level parallelism.
+Rejected because manifest sort and tree work are independent of chunk-index flush once manifest writing is complete, so handler-level overlap is real and valuable.
+
+### Decision 5: Finalization progress is modeled as two explicit event streams
+
+Add two notification events:
+
+- `ChunkIndexFlushProgressEvent(int ShardsCompleted, int TotalShards)`
+- `TreeUploadProgressEvent(int BlobsUploaded, int TotalBlobs)`
+
+These are emitted by the components doing the work, not synthesized afterward. The CLI can then render finalization progress as two concurrent progress lines instead of appearing stalled between upload completion and snapshot creation.
+
+Alternative considered: a single generic "archive phase changed" event.
+Rejected because it loses the two independent denominators the CLI needs for meaningful progress display.
+
+### Decision 6: Manifest sort remains a separate prerequisite for tree computation
+
+`ManifestSorter.SortAsync()` stays separate for now. We will overlap it with chunk-index flush but not fold it into tree-building changes in this design.
+
+This keeps the scope on finalization parallelism rather than mixing in a larger manifest-sorting redesign. If sort later becomes a dominant bottleneck, that can be addressed independently.
+
+There is one manifest temp file per archive run, not multiple manifests sorted in parallel. The relevant concurrency is therefore between the single manifest-sort/tree branch and the chunk-index flush branch.
+
+### Decision 7: Snapshot remains the only repository commit point
+
+Parallel finalization work may leave partial remote state behind if the run fails: some chunk-index shards may have flushed and some filetrees may have uploaded. That is acceptable only because the repository is not considered committed until `SnapshotService.CreateAsync()` publishes the new snapshot.
+
+This design relies on the following invariant:
+
+- Pre-snapshot finalization artifacts are recoverable tentative state.
+- The latest snapshot is the only authoritative description of repository state.
+- Local caches must never convert tentative local work into claimed remote truth prematurely.
+
+That is why tree upload temp spool files are separate from the final filetree cache path, and why cache validation remains explicit.
+
+### Decision 8: Terminology note for manifest vs snapshot
+
+The current domain language uses `manifest` for two different things:
+
+- the temporary on-disk file-entry input to tree building
+- the durable snapshot JSON object stored under `snapshots/`
+
+That overlap is confusing. This change does not rename either artifact, but it records the issue so domain language can later be normalized. A likely direction is to reserve `snapshot` for the durable repository commit object and use a more specific term such as `tree-build manifest` or `archive manifest` for the temporary sorted-input file.
+
+## Risks / Trade-offs
+
+- **Parallel flush increases service-internal concurrency pressure** -> Mitigation: snapshot pending entries into per-prefix groups before worker launch, keep L1 promotion under the existing lock, and use one progress counter per flush operation.
+- **Tree compute/upload pipeline can increase temp-disk usage** -> Mitigation: use bounded channels, delete temp spool files after upload, and keep spool files outside the final cache path so crash recovery can distinguish tentative local work from confirmed remote state.
+- **Slow-path validation may still dominate some runs** -> Mitigation: accept that the slow path is a different cost center. This change focuses on the serialized flush and tree-upload tail, while validation remains correct and explicit.
+- **Progress events from parallel workers can arrive out of order** -> Mitigation: events carry completed/total counts rather than assuming ordered delivery.
+- **Concurrency split across handler and services can blur ownership** -> Mitigation: keep validation and tree-upload internals inside `FileTreeBuilder`, keep per-prefix shard work inside `ChunkIndexService`, and let `ArchiveCommandHandler` only compose the two high-level branches.
+- **Partial remote updates can look like corruption** -> Mitigation: treat snapshot publication as the commit point, design caches as hints rather than truth, and keep finalization idempotent and retry-safe.
+
+## Migration Plan
+
+1. Remove the redundant archive-handler call to `FileTreeService.ValidateAsync()`.
+2. Refactor `FileTreeBuilder.BuildAsync()` into local compute first, then parallel upload of missing tree blobs.
+3. Refactor `ChunkIndexService.FlushAsync()` to snapshot touched prefixes and flush them in parallel.
+4. Update `ArchiveCommandHandler` to overlap flush with sort/tree finalization while preserving snapshot-after-both semantics.
+5. Add finalization progress events and CLI handlers.
+6. Add tests for validation ownership, bounded disk-spooled tree behavior, parallel flush correctness, orchestration ordering, and progress emission.
+
+Rollback is straightforward because the change does not alter repository layout: restore sequential orchestration and the prior inline tree upload behavior if the new concurrency shape proves awkward.
+
+## Open Questions
+
+- Whether `ManifestSorter.SortAsync()` is small enough in practice to leave as-is once flush and tree upload are parallelized.

--- a/openspec/changes/parallel-flush-and-tree-upload/proposal.md
+++ b/openspec/changes/parallel-flush-and-tree-upload/proposal.md
@@ -1,28 +1,31 @@
 ## Why
 
-The archive pipeline's end-of-pipeline phases — chunk-index flush and filetree build/upload — are entirely sequential today. Chunk-index shards are flushed one at a time with `foreach`, tree blobs are uploaded one at a time via `EnsureUploadedAsync`, and the two phases run back-to-back. At 1M-chunk scale (~29K touched shards, hundreds of tree blobs), this takes over 4 hours. Parallelizing these independent I/O-bound operations and running the two phases concurrently can reduce this to seconds. Additionally, reducing the shard prefix from 4 hex chars to 3 consolidates 65,536 possible shards into 4,096, reducing per-shard overhead at scale. Neither phase emits progress events, leaving the user with no feedback during the longest part of an archive run.
+The archive pipeline still ends with a serialized finalization tail. After uploads complete, it validates filetree cache state, flushes chunk-index shards one prefix at a time, sorts the manifest, builds filetrees while uploading each tree immediately, and only then creates the snapshot. The codebase has evolved since this idea was first proposed: `FileTreeBuilder` now owns the `FileTreeService.ValidateAsync` precondition for tree existence checks, and shard-prefix layout is a separate storage-contract question. We want to speed up finalization without coupling it to a repository layout change.
 
 ## What Changes
 
-- **Parallel chunk-index flush**: `ChunkIndexService.FlushAsync` changes from sequential `foreach` over modified shards to `Parallel.ForEachAsync` with configurable concurrency (default 32 workers). Each shard's load → merge → serialize → upload pipeline is independent.
-- **3-char shard prefix**: **BREAKING** — The chunk-index shard key changes from 4 hex characters (65,536 shards) to 3 hex characters (4,096 shards). Shard blob paths change from `chunk-index/abcd` to `chunk-index/abc`. At 1M entries this yields ~244 entries/shard (~5 KB gzipped) — a good balance between shard count and shard size. This is a development-only breaking change; no migration is needed.
-- **Separate tree compute from upload**: Tree construction splits into two phases: (1) sequential hash computation (CPU-bound, ~ms per blob), then (2) parallel upload of all tree blobs that need uploading, using `Parallel.ForEachAsync` with 32 workers.
-- **Concurrent flush + tree build**: Chunk-index flush and tree build/upload run concurrently via `Task.WhenAll` instead of sequentially. These phases are independent — flush writes to `chunk-index/`, tree build writes to `filetrees/`.
-- **Progress events for flush and tree upload**: Two new notification events: `ChunkIndexFlushProgressEvent(int ShardsCompleted, int TotalShards)` and `TreeUploadProgressEvent(int BlobsUploaded, int TotalBlobs)`. These enable the CLI to show two parallel progress lines during the end-of-pipeline phase.
+- **Parallel chunk-index flush**: `ChunkIndexService.FlushAsync` keeps the current shard format but flushes touched prefixes in parallel with configurable concurrency. Each worker performs load -> merge -> serialize -> upload -> cache update for one prefix.
+- **Separate tree hash computation from upload**: `FileTreeBuilder.BuildAsync` performs one validation pass, computes all directory tree blobs and hashes from the sorted manifest without further remote calls, then uploads only missing tree blobs in parallel.
+- **Concurrent finalization work**: after manifest writing completes, archive finalization overlaps independent work instead of running it strictly back-to-back. Chunk-index flush runs concurrently with manifest sort, tree hash computation, and tree upload where dependencies allow; snapshot creation still waits for both finalization branches to finish.
+- **Progress events for finalization**: add `ChunkIndexFlushProgressEvent(int ShardsCompleted, int TotalShards)` and `TreeUploadProgressEvent(int BlobsUploaded, int TotalBlobs)` so the CLI can show explicit progress during the longest end-of-pipeline phase.
+- **Single validation owner**: the archive pipeline keeps one owner for filetree validation. If `FileTreeBuilder.BuildAsync` validates before using `ExistsInRemote`, `ArchiveCommandHandler` SHALL not perform a redundant pre-validation call.
+
+## Non-goals
+
+- Changing chunk-index shard prefix length or blob naming format. That storage-layout work is tracked separately.
 
 ## Capabilities
 
 ### New Capabilities
-- `parallel-flush-and-tree-upload`: Parallel chunk-index flush, parallel tree blob upload, concurrent execution of both via `Task.WhenAll`, 3-char shard prefix, and progress events for both phases.
+- `parallel-flush-and-tree-upload`: Parallel chunk-index flush, parallel tree blob upload, overlapped end-of-pipeline execution, and explicit finalization progress events.
 
 ### Modified Capabilities
-- `archive-pipeline`: End-of-pipeline changes from sequential flush → build → snapshot to concurrent (flush ∥ tree-build) → snapshot. New progress events emitted during flush and tree upload.
-- `blob-storage`: Chunk-index shard blob path format changes from `chunk-index/<4-char-prefix>` to `chunk-index/<3-char-prefix>`.
+- `archive-pipeline`: End-of-pipeline changes from serialized validate -> flush -> sort -> build -> snapshot to an overlapped finalization flow with one validation owner and parallel progress reporting.
 
 ## Impact
 
-- **Core layer** (`Arius.Core`): `ChunkIndexService.FlushAsync` and `FileTreeBuilder.BuildAsync` change significantly. `ArchiveCommandHandler` wires `Task.WhenAll` for the two phases.
-- **Shard path format**: `chunk-index/` blob paths change from 4-char to 3-char prefixes. Existing L2 disk cache files become stale (acceptable — cache miss falls through to L3). Existing Azure shards from prior development archives become orphaned (acceptable — still in development, no production data).
-- **New events**: `ChunkIndexFlushProgressEvent` and `TreeUploadProgressEvent` added to archive events. CLI display layer will consume these for parallel progress lines.
-- **Performance**: At 1M-chunk scale, estimated end-of-pipeline time drops from ~265 minutes (sequential) to ~13 seconds (parallel, epoch-match fast path) or ~23 seconds (slow path with prefetch).
-- **Tests**: New tests for parallel flush (verify all shards uploaded, concurrency correctness), parallel tree upload, concurrent execution, 3-char prefix shard paths, and progress event emission.
+- **Core layer** (`Arius.Core`): `ChunkIndexService.FlushAsync` and `FileTreeBuilder.BuildAsync` change significantly. `ArchiveCommandHandler` changes orchestration only where concurrency boundaries belong there.
+- **No repository layout change**: `chunk-index/<prefix>` naming and current shard prefix length stay unchanged in this change.
+- **New events**: `ChunkIndexFlushProgressEvent` and `TreeUploadProgressEvent` are added to archive events and consumed by CLI progress display.
+- **Performance focus**: this change targets the end-of-pipeline tail dominated by sequential shard flush and sequential tree upload, while leaving shard-layout optimization for a follow-up change.
+- **Tests**: add coverage for parallel flush correctness, two-phase tree build/upload behavior, concurrent finalization orchestration, single-owner validation, and progress event emission.

--- a/openspec/changes/parallel-flush-and-tree-upload/proposal.md
+++ b/openspec/changes/parallel-flush-and-tree-upload/proposal.md
@@ -2,13 +2,16 @@
 
 The archive pipeline still ends with a serialized finalization tail. After uploads complete, it validates filetree cache state, flushes chunk-index shards one prefix at a time, sorts the manifest, builds filetrees while uploading each tree immediately, and only then creates the snapshot. The codebase has evolved since this idea was first proposed: `FileTreeBuilder` now owns the `FileTreeService.ValidateAsync` precondition for tree existence checks, and shard-prefix layout is a separate storage-contract question. We want to speed up finalization without coupling it to a repository layout change.
 
+This change must remain grounded in Arius's operating constraints. Arius is a backup tool for important files, so durability and recoverability matter more than shaving off a little complexity. Repository scale can be large in bytes and large in file count: potentially terabyte-scale binary content with many thousands of small files. Blob storage is non-transactional across blobs, and local cache state can be stale or corrupt. Any finalization parallelism must preserve a clear commit point at snapshot creation and remain recoverable after partial uploads, partial shard flushes, and cache divergence.
+
 ## What Changes
 
 - **Parallel chunk-index flush**: `ChunkIndexService.FlushAsync` keeps the current shard format but flushes touched prefixes in parallel with configurable concurrency. Each worker performs load -> merge -> serialize -> upload -> cache update for one prefix.
-- **Separate tree hash computation from upload**: `FileTreeBuilder.BuildAsync` performs one validation pass, computes all directory tree blobs and hashes from the sorted manifest without further remote calls, then uploads only missing tree blobs in parallel.
+- **Bounded tree compute/upload pipeline**: `FileTreeBuilder.BuildAsync` performs one validation pass, computes directory tree blobs and hashes from the sorted manifest without further remote calls, writes upload-needed trees to bounded temporary spool files on disk, and lets parallel upload workers consume that spool. This preserves low memory usage even when the repository contains many directories.
 - **Concurrent finalization work**: after manifest writing completes, archive finalization overlaps independent work instead of running it strictly back-to-back. Chunk-index flush runs concurrently with manifest sort, tree hash computation, and tree upload where dependencies allow; snapshot creation still waits for both finalization branches to finish.
 - **Progress events for finalization**: add `ChunkIndexFlushProgressEvent(int ShardsCompleted, int TotalShards)` and `TreeUploadProgressEvent(int BlobsUploaded, int TotalBlobs)` so the CLI can show explicit progress during the longest end-of-pipeline phase.
 - **Single validation owner**: the archive pipeline keeps one owner for filetree validation. If `FileTreeBuilder.BuildAsync` validates before using `ExistsInRemote`, `ArchiveCommandHandler` SHALL not perform a redundant pre-validation call.
+- **Terminology cleanup note**: this change records that `manifest` currently refers to the temporary file-entry input to tree building, while `snapshot manifest` refers to the durable repository commit object. The naming overlap is confusing and should be normalized in domain language/docs as a follow-up consistency cleanup.
 
 ## Non-goals
 
@@ -28,4 +31,5 @@ The archive pipeline still ends with a serialized finalization tail. After uploa
 - **No repository layout change**: `chunk-index/<prefix>` naming and current shard prefix length stay unchanged in this change.
 - **New events**: `ChunkIndexFlushProgressEvent` and `TreeUploadProgressEvent` are added to archive events and consumed by CLI progress display.
 - **Performance focus**: this change targets the end-of-pipeline tail dominated by sequential shard flush and sequential tree upload, while leaving shard-layout optimization for a follow-up change.
-- **Tests**: add coverage for parallel flush correctness, two-phase tree build/upload behavior, concurrent finalization orchestration, single-owner validation, and progress event emission.
+- **Durability constraints**: partial finalization work before snapshot creation is acceptable only as recoverable orphaned state; snapshot creation remains the repository commit point.
+- **Tests**: add coverage for parallel flush correctness, bounded tree compute/upload behavior, concurrent finalization orchestration, single-owner validation, and progress event emission.

--- a/openspec/changes/parallel-flush-and-tree-upload/tasks.md
+++ b/openspec/changes/parallel-flush-and-tree-upload/tasks.md
@@ -1,0 +1,32 @@
+## 1. Validation Ownership And Finalization Shape
+
+- [ ] 1.1 Remove the redundant `ArchiveCommandHandler` call to `FileTreeService.ValidateAsync()` so `FileTreeBuilder` remains the single validation owner for tree existence checks
+- [ ] 1.2 Refactor archive end-of-pipeline orchestration so chunk-index flush overlaps with the manifest-sort/tree branch while `SnapshotService.CreateAsync()` still waits for both branches to finish
+- [ ] 1.3 Add or update tests that assert snapshot creation does not occur until both flush and tree upload work complete
+
+## 2. Parallel Chunk-Index Flush
+
+- [ ] 2.1 Refactor `ChunkIndexService.FlushAsync()` to snapshot pending entries into per-prefix groups before worker launch
+- [ ] 2.2 Flush touched shard prefixes in parallel with bounded concurrency, preserving the existing per-prefix load -> merge -> serialize -> upload -> L2 save -> L1 promote flow
+- [ ] 2.3 Emit `ChunkIndexFlushProgressEvent(int ShardsCompleted, int TotalShards)` during parallel flush
+- [ ] 2.4 Add tests for parallel flush correctness, including all touched prefixes uploaded, L2/L1 cache updates preserved, and duplicate/overlapping content hashes merged correctly under concurrency
+
+## 3. Bounded Tree Compute/Upload Pipeline
+
+- [ ] 3.1 Refactor `FileTreeBuilder.BuildAsync()` so directory hash computation remains local after validation and does not depend on remote upload completion
+- [ ] 3.2 Introduce a bounded producer/consumer pipeline for upload-needed tree blobs: compute writes temporary spool files outside the final filetree cache directory, upload workers consume descriptors from a bounded channel
+- [ ] 3.3 Publish plaintext tree bytes into the final filetree cache path only after upload succeeds, so crash recovery can distinguish tentative local spool state from confirmed remote existence
+- [ ] 3.4 Emit `TreeUploadProgressEvent(int BlobsUploaded, int TotalBlobs)` during tree upload
+- [ ] 3.5 Add tests for bounded disk-spooled tree upload behavior, including deduplicated trees skipped without upload, successful uploads populating the final cache, and interrupted runs not leaving false-positive final cache entries
+
+## 4. CLI Finalization Progress
+
+- [ ] 4.1 Add CLI notification handlers and progress-state support for chunk-index flush progress and tree upload progress
+- [ ] 4.2 Update archive progress rendering so finalization shows explicit concurrent progress instead of appearing stalled after chunk upload completes
+- [ ] 4.3 Add CLI tests that verify finalization progress remains correct when progress events arrive out of order from parallel workers
+
+## 5. Verification
+
+- [ ] 5.1 Run unit and integration tests covering archive finalization, filetree caching, chunk-index flush, and archive CLI progress
+- [ ] 5.2 Add a regression test documenting that snapshot creation remains the only repository commit point: partial flush/tree-upload work before snapshot must not be treated as a completed archive state
+- [ ] 5.3 Review domain-language/docs touchpoints for the temporary archive manifest versus durable snapshot naming overlap and capture any follow-up cleanup work without renaming storage artifacts in this change

--- a/openspec/changes/parallel-flush-and-tree-upload/tasks.md
+++ b/openspec/changes/parallel-flush-and-tree-upload/tasks.md
@@ -1,32 +1,32 @@
 ## 1. Validation Ownership And Finalization Shape
 
-- [ ] 1.1 Remove the redundant `ArchiveCommandHandler` call to `FileTreeService.ValidateAsync()` so `FileTreeBuilder` remains the single validation owner for tree existence checks
-- [ ] 1.2 Refactor archive end-of-pipeline orchestration so chunk-index flush overlaps with the manifest-sort/tree branch while `SnapshotService.CreateAsync()` still waits for both branches to finish
-- [ ] 1.3 Add or update tests that assert snapshot creation does not occur until both flush and tree upload work complete
+- [x] 1.1 Remove the redundant `ArchiveCommandHandler` call to `FileTreeService.ValidateAsync()` so `FileTreeBuilder` remains the single validation owner for tree existence checks
+- [x] 1.2 Refactor archive end-of-pipeline orchestration so chunk-index flush overlaps with the manifest-sort/tree branch while `SnapshotService.CreateAsync()` still waits for both branches to finish
+- [x] 1.3 Add or update tests that assert snapshot creation does not occur until both flush and tree upload work complete
 
 ## 2. Parallel Chunk-Index Flush
 
-- [ ] 2.1 Refactor `ChunkIndexService.FlushAsync()` to snapshot pending entries into per-prefix groups before worker launch
-- [ ] 2.2 Flush touched shard prefixes in parallel with bounded concurrency, preserving the existing per-prefix load -> merge -> serialize -> upload -> L2 save -> L1 promote flow
-- [ ] 2.3 Emit `ChunkIndexFlushProgressEvent(int ShardsCompleted, int TotalShards)` during parallel flush
-- [ ] 2.4 Add tests for parallel flush correctness, including all touched prefixes uploaded, L2/L1 cache updates preserved, and duplicate/overlapping content hashes merged correctly under concurrency
+- [x] 2.1 Refactor `ChunkIndexService.FlushAsync()` to snapshot pending entries into per-prefix groups before worker launch
+- [x] 2.2 Flush touched shard prefixes in parallel with bounded concurrency, preserving the existing per-prefix load -> merge -> serialize -> upload -> L2 save -> L1 promote flow
+- [x] 2.3 Emit `ChunkIndexFlushProgressEvent(int ShardsCompleted, int TotalShards)` during parallel flush
+- [x] 2.4 Add tests for parallel flush correctness, including all touched prefixes uploaded, L2/L1 cache updates preserved, and duplicate/overlapping content hashes merged correctly under concurrency
 
 ## 3. Bounded Tree Compute/Upload Pipeline
 
-- [ ] 3.1 Refactor `FileTreeBuilder.BuildAsync()` so directory hash computation remains local after validation and does not depend on remote upload completion
-- [ ] 3.2 Introduce a bounded producer/consumer pipeline for upload-needed tree blobs: compute writes temporary spool files outside the final filetree cache directory, upload workers consume descriptors from a bounded channel
-- [ ] 3.3 Publish plaintext tree bytes into the final filetree cache path only after upload succeeds, so crash recovery can distinguish tentative local spool state from confirmed remote existence
-- [ ] 3.4 Emit `TreeUploadProgressEvent(int BlobsUploaded, int TotalBlobs)` during tree upload
-- [ ] 3.5 Add tests for bounded disk-spooled tree upload behavior, including deduplicated trees skipped without upload, successful uploads populating the final cache, and interrupted runs not leaving false-positive final cache entries
+- [x] 3.1 Refactor `FileTreeBuilder.BuildAsync()` so directory hash computation remains local after validation and does not depend on remote upload completion
+- [x] 3.2 Introduce a bounded producer/consumer pipeline for upload-needed tree blobs: compute writes temporary spool files outside the final filetree cache directory, upload workers consume descriptors from a bounded channel
+- [x] 3.3 Publish plaintext tree bytes into the final filetree cache path only after upload succeeds, so crash recovery can distinguish tentative local spool state from confirmed remote existence
+- [x] 3.4 Emit `TreeUploadProgressEvent(int BlobsUploaded, int TotalBlobs)` during tree upload
+- [x] 3.5 Add tests for bounded disk-spooled tree upload behavior, including deduplicated trees skipped without upload, successful uploads populating the final cache, and interrupted runs not leaving false-positive final cache entries
 
 ## 4. CLI Finalization Progress
 
-- [ ] 4.1 Add CLI notification handlers and progress-state support for chunk-index flush progress and tree upload progress
-- [ ] 4.2 Update archive progress rendering so finalization shows explicit concurrent progress instead of appearing stalled after chunk upload completes
-- [ ] 4.3 Add CLI tests that verify finalization progress remains correct when progress events arrive out of order from parallel workers
+- [x] 4.1 Add CLI notification handlers and progress-state support for chunk-index flush progress and tree upload progress
+- [x] 4.2 Update archive progress rendering so finalization shows explicit concurrent progress instead of appearing stalled after chunk upload completes
+- [x] 4.3 Add CLI tests that verify finalization progress remains correct when progress events arrive out of order from parallel workers
 
 ## 5. Verification
 
-- [ ] 5.1 Run unit and integration tests covering archive finalization, filetree caching, chunk-index flush, and archive CLI progress
-- [ ] 5.2 Add a regression test documenting that snapshot creation remains the only repository commit point: partial flush/tree-upload work before snapshot must not be treated as a completed archive state
-- [ ] 5.3 Review domain-language/docs touchpoints for the temporary archive manifest versus durable snapshot naming overlap and capture any follow-up cleanup work without renaming storage artifacts in this change
+- [x] 5.1 Run unit and integration tests covering archive finalization, filetree caching, chunk-index flush, and archive CLI progress
+- [x] 5.2 Add a regression test documenting that snapshot creation remains the only repository commit point: partial flush/tree-upload work before snapshot must not be treated as a completed archive state
+- [x] 5.3 Review domain-language/docs touchpoints for the temporary archive manifest versus durable snapshot naming overlap and capture any follow-up cleanup work without renaming storage artifacts in this change

--- a/src/Arius.Cli.Tests/Commands/Archive/BuildArchiveDisplayTests.cs
+++ b/src/Arius.Cli.Tests/Commands/Archive/BuildArchiveDisplayTests.cs
@@ -155,6 +155,44 @@ public class BuildArchiveDisplayTests
         uploadingLine.ShouldContain("○");
     }
 
+    [Test]
+    public void BuildArchiveDisplay_ShowsChunkIndexFinalizationProgress_WhenPresent()
+    {
+        var state = new ProgressState();
+        state.SetChunkIndexFlushProgress(2, 5);
+
+        var output = RenderToString(ArchiveVerb.BuildDisplay(state));
+        var line = GetLineContaining(output, "Finalizing Index");
+
+        line.ShouldContain("2 / 5 shards");
+        line.ShouldContain("○");
+    }
+
+    [Test]
+    public void BuildArchiveDisplay_ShowsTreeUploadProgress_WhenPresent()
+    {
+        var state = new ProgressState();
+        state.SetTreeUploadProgress(3, 4);
+
+        var output = RenderToString(ArchiveVerb.BuildDisplay(state));
+        var line = GetLineContaining(output, "Uploading Trees");
+
+        line.ShouldContain("3 / 4 blobs");
+        line.ShouldContain("○");
+    }
+
+    [Test]
+    public void BuildArchiveDisplay_FinalizationRows_UseFilledCircle_WhenComplete()
+    {
+        var state = new ProgressState();
+        state.SetChunkIndexFlushProgress(5, 5);
+        state.SetTreeUploadProgress(4, 4);
+
+        var output = RenderToString(ArchiveVerb.BuildDisplay(state));
+        GetLineContaining(output, "Finalizing Index").ShouldContain("●");
+        GetLineContaining(output, "Uploading Trees").ShouldContain("●");
+    }
+
     // ── 6.4 Per-file lines: only Hashing or Uploading ────────────────────────
 
     [Test]

--- a/src/Arius.Cli.Tests/Commands/Archive/NotificationHandlerTests.cs
+++ b/src/Arius.Cli.Tests/Commands/Archive/NotificationHandlerTests.cs
@@ -245,4 +245,46 @@ public class NotificationHandlerTests
 
         state.SnapshotComplete.ShouldBeTrue();
     }
+
+    [Test]
+    public async Task ChunkIndexFlushProgressHandler_SetsFinalizationProgress()
+    {
+        var state = new ProgressState();
+        var handler = new ChunkIndexFlushProgressHandler(state);
+
+        await handler.Handle(new ChunkIndexFlushProgressEvent(2, 5), CancellationToken.None);
+
+        state.ChunkIndexFlushCompletedShards.ShouldBe(2);
+        state.ChunkIndexFlushTotalShards.ShouldBe(5);
+    }
+
+    [Test]
+    public async Task TreeUploadProgressHandler_SetsFinalizationProgress()
+    {
+        var state = new ProgressState();
+        var handler = new TreeUploadProgressHandler(state);
+
+        await handler.Handle(new TreeUploadProgressEvent(4, 7), CancellationToken.None);
+
+        state.TreeUploadCompletedBlobs.ShouldBe(4);
+        state.TreeUploadTotalBlobs.ShouldBe(7);
+    }
+
+    [Test]
+    public async Task FinalizationProgressHandlers_KeepLatestCounts_WhenEventsArriveOutOfOrder()
+    {
+        var state = new ProgressState();
+        var flushHandler = new ChunkIndexFlushProgressHandler(state);
+        var treeHandler = new TreeUploadProgressHandler(state);
+
+        await flushHandler.Handle(new ChunkIndexFlushProgressEvent(3, 5), CancellationToken.None);
+        await flushHandler.Handle(new ChunkIndexFlushProgressEvent(2, 5), CancellationToken.None);
+        await treeHandler.Handle(new TreeUploadProgressEvent(4, 7), CancellationToken.None);
+        await treeHandler.Handle(new TreeUploadProgressEvent(1, 7), CancellationToken.None);
+
+        state.ChunkIndexFlushCompletedShards.ShouldBe(2);
+        state.ChunkIndexFlushTotalShards.ShouldBe(5);
+        state.TreeUploadCompletedBlobs.ShouldBe(1);
+        state.TreeUploadTotalBlobs.ShouldBe(7);
+    }
 }

--- a/src/Arius.Cli.Tests/MediatorEventRoutingIntegrationTests.cs
+++ b/src/Arius.Cli.Tests/MediatorEventRoutingIntegrationTests.cs
@@ -54,6 +54,8 @@ public class MediatorEventRoutingIntegrationTests
         await mediator.Publish(new TarBundleSealingEvent(1, 100, "tar1", ["hash1"]));
         await mediator.Publish(new ChunkUploadingEvent("tar1", 100));
         await mediator.Publish(new TarBundleUploadedEvent("tar1", 80, 1));
+        await mediator.Publish(new ChunkIndexFlushProgressEvent(2, 4));
+        await mediator.Publish(new TreeUploadProgressEvent(3, 5));
         await mediator.Publish(new SnapshotCreatedEvent("root", DateTimeOffset.UtcNow, 1));
 
         // Verify ProgressState was updated
@@ -62,6 +64,10 @@ public class MediatorEventRoutingIntegrationTests
         state.ScanComplete.ShouldBeTrue();
         state.FilesHashed.ShouldBe(1L);
         state.TarsUploaded.ShouldBe(1L);
+        state.ChunkIndexFlushCompletedShards.ShouldBe(2);
+        state.ChunkIndexFlushTotalShards.ShouldBe(4);
+        state.TreeUploadCompletedBlobs.ShouldBe(3);
+        state.TreeUploadTotalBlobs.ShouldBe(5);
         // a.bin was removed after tar entry added
         state.TrackedFiles.ContainsKey("a.bin").ShouldBeFalse();
         state.SnapshotComplete.ShouldBeTrue();

--- a/src/Arius.Cli/Commands/Archive/ArchiveProgressHandlers.cs
+++ b/src/Arius.Cli/Commands/Archive/ArchiveProgressHandlers.cs
@@ -185,6 +185,28 @@ public sealed class TarBundleUploadedHandler(ProgressState state) : INotificatio
     }
 }
 
+// ── ChunkIndexFlushProgressHandler ────────────────────────────────────────────
+
+public sealed class ChunkIndexFlushProgressHandler(ProgressState state) : INotificationHandler<ChunkIndexFlushProgressEvent>
+{
+    public ValueTask Handle(ChunkIndexFlushProgressEvent notification, CancellationToken cancellationToken)
+    {
+        state.SetChunkIndexFlushProgress(notification.ShardsCompleted, notification.TotalShards);
+        return ValueTask.CompletedTask;
+    }
+}
+
+// ── TreeUploadProgressHandler ─────────────────────────────────────────────────
+
+public sealed class TreeUploadProgressHandler(ProgressState state) : INotificationHandler<TreeUploadProgressEvent>
+{
+    public ValueTask Handle(TreeUploadProgressEvent notification, CancellationToken cancellationToken)
+    {
+        state.SetTreeUploadProgress(notification.BlobsUploaded, notification.TotalBlobs);
+        return ValueTask.CompletedTask;
+    }
+}
+
 // ── SnapshotCreatedHandler ────────────────────────────────────────────────────
 
 /// <summary>Sets <see cref="ProgressState.SnapshotComplete"/> when the snapshot is created.</summary>

--- a/src/Arius.Cli/Commands/Archive/ArchiveVerb.cs
+++ b/src/Arius.Cli/Commands/Archive/ArchiveVerb.cs
@@ -270,6 +270,21 @@ internal static class ArchiveVerb
             }
         }
 
+        // ── Finalization headers ──────────────────────────────────────────────
+        if (state.ChunkIndexFlushTotalShards is { } flushTotal)
+        {
+            var flushDone = state.ChunkIndexFlushCompletedShards >= flushTotal;
+            var flushSymbol = flushDone ? "[green]●[/]" : "[yellow]○[/]";
+            lines.Add(new Markup($"  {flushSymbol} Finalizing Index [dim]{state.ChunkIndexFlushCompletedShards:N0} / {flushTotal:N0} shards[/]"));
+        }
+
+        if (state.TreeUploadTotalBlobs is { } treeTotal)
+        {
+            var treeDone = state.TreeUploadCompletedBlobs >= treeTotal;
+            var treeSymbol = treeDone ? "[green]●[/]" : "[yellow]○[/]";
+            lines.Add(new Markup($"  {treeSymbol} Uploading Trees [dim]{state.TreeUploadCompletedBlobs:N0} / {treeTotal:N0} blobs[/]"));
+        }
+
         // ── Per-file and TAR bundle rows ──────────────────────────────────────
         var activeFiles = state.TrackedFiles.Values
             .Where(f => f.State is FileState.Hashing or FileState.Uploading)

--- a/src/Arius.Cli/ProgressState.cs
+++ b/src/Arius.Cli/ProgressState.cs
@@ -434,6 +434,32 @@ public sealed class ProgressState
     /// <summary>Marks the snapshot as complete.</summary>
     public void SetSnapshotComplete() => Volatile.Write(ref _snapshotComplete, true);
 
+    // ── Archive: finalization progress ───────────────────────────────────────
+
+    public int? ChunkIndexFlushTotalShards => Volatile.Read(ref _chunkIndexFlushTotalShards) < 0 ? null : Volatile.Read(ref _chunkIndexFlushTotalShards);
+    private int _chunkIndexFlushTotalShards = -1;
+
+    public int ChunkIndexFlushCompletedShards => Volatile.Read(ref _chunkIndexFlushCompletedShards);
+    private int _chunkIndexFlushCompletedShards;
+
+    public void SetChunkIndexFlushProgress(int completed, int total)
+    {
+        Volatile.Write(ref _chunkIndexFlushCompletedShards, completed);
+        Volatile.Write(ref _chunkIndexFlushTotalShards, total);
+    }
+
+    public int? TreeUploadTotalBlobs => Volatile.Read(ref _treeUploadTotalBlobs) < 0 ? null : Volatile.Read(ref _treeUploadTotalBlobs);
+    private int _treeUploadTotalBlobs = -1;
+
+    public int TreeUploadCompletedBlobs => Volatile.Read(ref _treeUploadCompletedBlobs);
+    private int _treeUploadCompletedBlobs;
+
+    public void SetTreeUploadProgress(int completed, int total)
+    {
+        Volatile.Write(ref _treeUploadCompletedBlobs, completed);
+        Volatile.Write(ref _treeUploadTotalBlobs, total);
+    }
+
     // ── Restore ───────────────────────────────────────────────────────────────
 
     // ── Restore: active downloads ────────────────────────────────────────────

--- a/src/Arius.Core.Tests/Features/ArchiveCommand/ArchiveFinalizationTests.cs
+++ b/src/Arius.Core.Tests/Features/ArchiveCommand/ArchiveFinalizationTests.cs
@@ -1,0 +1,167 @@
+using Arius.Core.Features.ArchiveCommand;
+using Arius.Core.Shared;
+using Arius.Core.Shared.ChunkIndex;
+using Arius.Core.Shared.ChunkStorage;
+using Arius.Core.Shared.Encryption;
+using Arius.Core.Shared.FileTree;
+using Arius.Core.Shared.Snapshot;
+using Arius.Core.Shared.Storage;
+using Arius.Core.Tests.Features.ArchiveCommand.Fakes;
+using Mediator;
+using Microsoft.Extensions.Logging.Testing;
+using NSubstitute;
+using TUnit.Core;
+using ArchiveCommandType = Arius.Core.Features.ArchiveCommand.ArchiveCommand;
+
+namespace Arius.Core.Tests.Features.ArchiveCommand;
+
+public class ArchiveFinalizationTests
+{
+    [Test]
+    public async Task Archive_Finalization_OverlapsFlushWithTreeWork_AndWaitsForFlushBeforeSnapshot()
+    {
+        const string account = "acct-finalization";
+        var container = $"ctr-finalization-{Guid.NewGuid():N}";
+        var root = Path.Combine(Path.GetTempPath(), $"arius-finalization-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            await File.WriteAllBytesAsync(Path.Combine(root, "large.bin"), new byte[2 * 1024 * 1024]);
+            await File.WriteAllBytesAsync(Path.Combine(root, "small.txt"), new byte[256]);
+
+            var blobs = new CoordinatedArchiveBlobContainerService();
+            var encryption = new PlaintextPassthroughService();
+            var index = new ChunkIndexService(blobs, encryption, account, container);
+            var fileTreeService = new FileTreeService(blobs, encryption, index, account, container);
+            var snapshotService = new SnapshotService(blobs, encryption, account, container);
+            var chunkStorage = new ChunkStorageService(blobs, encryption);
+            var mediator = Substitute.For<IMediator>();
+            var logger = new FakeLogger<ArchiveCommandHandler>();
+
+            var handler = new ArchiveCommandHandler(
+                blobs,
+                encryption,
+                index,
+                chunkStorage,
+                fileTreeService,
+                snapshotService,
+                mediator,
+                logger,
+                account,
+                container);
+
+            var archiveTask = handler.Handle(
+                new ArchiveCommandType(new ArchiveCommandOptions
+                {
+                    RootDirectory = root,
+                    UploadTier = BlobTier.Hot,
+                }),
+                CancellationToken.None).AsTask();
+
+            await blobs.TreeUploadStarted.WaitAsync(TimeSpan.FromSeconds(5));
+            blobs.IndexUploadCompleted.IsCompleted.ShouldBeFalse("tree upload should start before index flush completes");
+
+            blobs.AllowTreeUpload();
+            blobs.AllowIndexUpload();
+
+            var result = await archiveTask;
+
+            result.Success.ShouldBeTrue(result.ErrorMessage);
+            blobs.SnapshotUploadedBeforeIndexCompleted.ShouldBeFalse("snapshot must wait for chunk-index flush completion");
+            blobs.IndexUploadCompleted.IsCompleted.ShouldBeTrue();
+
+            await mediator.Received().Publish(
+                Arg.Is<ChunkIndexFlushProgressEvent>(e => e.ShardsCompleted >= 1 && e.TotalShards >= 1),
+                Arg.Any<CancellationToken>());
+
+            await mediator.Received().Publish(
+                Arg.Is<TreeUploadProgressEvent>(e => e.BlobsUploaded >= 1 && e.TotalBlobs >= 1),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+
+            var repoDir = RepositoryPaths.GetRepositoryDirectory(account, container);
+            if (Directory.Exists(repoDir))
+                Directory.Delete(repoDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Archive_PartialFinalizationBeforeSnapshot_DoesNotCreateCompletedArchiveState()
+    {
+        const string account = "acct-commit-point";
+        var container = $"ctr-commit-point-{Guid.NewGuid():N}";
+        var root = Path.Combine(Path.GetTempPath(), $"arius-commit-point-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            await File.WriteAllBytesAsync(Path.Combine(root, "large.bin"), new byte[2 * 1024 * 1024]);
+            await File.WriteAllBytesAsync(Path.Combine(root, "small.txt"), new byte[256]);
+
+            var blobs = new CoordinatedArchiveBlobContainerService();
+            var encryption = new PlaintextPassthroughService();
+            var index = new ChunkIndexService(blobs, encryption, account, container);
+            var fileTreeService = new FileTreeService(blobs, encryption, index, account, container);
+            var snapshotService = new SnapshotService(blobs, encryption, account, container);
+            var chunkStorage = new ChunkStorageService(blobs, encryption);
+            var mediator = Substitute.For<IMediator>();
+            var logger = new FakeLogger<ArchiveCommandHandler>();
+
+            var handler = new ArchiveCommandHandler(
+                blobs,
+                encryption,
+                index,
+                chunkStorage,
+                fileTreeService,
+                snapshotService,
+                mediator,
+                logger,
+                account,
+                container);
+
+            var archiveTask = handler.Handle(
+                new ArchiveCommandType(new ArchiveCommandOptions
+                {
+                    RootDirectory = root,
+                    UploadTier = BlobTier.Hot,
+                }),
+                CancellationToken.None).AsTask();
+
+            await blobs.TreeUploadStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+            blobs.HasAnyBlobWithPrefix(BlobPaths.Snapshots).ShouldBeFalse();
+
+            blobs.AllowTreeUpload();
+            await blobs.TreeUploadCompleted.WaitAsync(TimeSpan.FromSeconds(5));
+
+            blobs.HasAnyBlobWithPrefix(BlobPaths.FileTrees).ShouldBeTrue();
+            blobs.HasAnyBlobWithPrefix(BlobPaths.Snapshots).ShouldBeFalse();
+
+            var visibleSnapshotBeforeCommit = await snapshotService.ResolveAsync();
+            visibleSnapshotBeforeCommit.ShouldBeNull();
+
+            blobs.AllowIndexUpload();
+
+            var result = await archiveTask;
+
+            result.Success.ShouldBeTrue(result.ErrorMessage);
+
+            var visibleSnapshotAfterCommit = await snapshotService.ResolveAsync();
+            visibleSnapshotAfterCommit.ShouldNotBeNull();
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+
+            var repoDir = RepositoryPaths.GetRepositoryDirectory(account, container);
+            if (Directory.Exists(repoDir))
+                Directory.Delete(repoDir, recursive: true);
+        }
+    }
+}

--- a/src/Arius.Core.Tests/Features/ArchiveCommand/Fakes/CoordinatedArchiveBlobContainerService.cs
+++ b/src/Arius.Core.Tests/Features/ArchiveCommand/Fakes/CoordinatedArchiveBlobContainerService.cs
@@ -1,0 +1,132 @@
+using System.Collections.Concurrent;
+using Arius.Core.Shared.Storage;
+
+namespace Arius.Core.Tests.Features.ArchiveCommand.Fakes;
+
+internal sealed class CoordinatedArchiveBlobContainerService : IBlobContainerService
+{
+    private readonly ConcurrentDictionary<string, StoredBlob> _blobs = new(StringComparer.Ordinal);
+    private readonly TaskCompletionSource _treeUploadStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _allowTreeUpload = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _treeUploadCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _allowIndexUpload = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _indexUploadCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task TreeUploadStarted => _treeUploadStarted.Task;
+    public Task TreeUploadCompleted => _treeUploadCompleted.Task;
+    public Task IndexUploadCompleted => _indexUploadCompleted.Task;
+
+    public bool SnapshotUploadedBeforeIndexCompleted { get; private set; }
+
+    public void AllowTreeUpload() => _allowTreeUpload.TrySetResult();
+
+    public void AllowIndexUpload() => _allowIndexUpload.TrySetResult();
+
+    public bool HasAnyBlobWithPrefix(string prefix) => _blobs.Keys.Any(name => name.StartsWith(prefix, StringComparison.Ordinal));
+
+    public Task CreateContainerIfNotExistsAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public async Task UploadAsync(string blobName, Stream content, IReadOnlyDictionary<string, string> metadata, BlobTier tier, string? contentType = null, bool overwrite = false, CancellationToken cancellationToken = default)
+    {
+        if (blobName.StartsWith(BlobPaths.FileTrees, StringComparison.Ordinal))
+        {
+            _treeUploadStarted.TrySetResult();
+            await _allowTreeUpload.Task.WaitAsync(cancellationToken);
+        }
+
+        if (blobName.StartsWith(BlobPaths.ChunkIndex, StringComparison.Ordinal))
+            await _allowIndexUpload.Task.WaitAsync(cancellationToken);
+
+        if (blobName.StartsWith(BlobPaths.Snapshots, StringComparison.Ordinal) && !_indexUploadCompleted.Task.IsCompleted)
+            SnapshotUploadedBeforeIndexCompleted = true;
+
+        await using var ms = new MemoryStream();
+        await content.CopyToAsync(ms, cancellationToken);
+        _blobs[blobName] = new StoredBlob(ms.ToArray(), new Dictionary<string, string>(metadata), tier, contentType, false);
+
+        if (blobName.StartsWith(BlobPaths.FileTrees, StringComparison.Ordinal))
+            _treeUploadCompleted.TrySetResult();
+
+        if (blobName.StartsWith(BlobPaths.ChunkIndex, StringComparison.Ordinal))
+            _indexUploadCompleted.TrySetResult();
+    }
+
+    public Task<Stream> OpenWriteAsync(string blobName, string? contentType = null, CancellationToken cancellationToken = default)
+        => Task.FromResult<Stream>(new CommitOnDisposeStream(bytes =>
+        {
+            _blobs[blobName] = new StoredBlob(bytes, new Dictionary<string, string>(), null, contentType, false);
+        }));
+
+    public Task<Stream> DownloadAsync(string blobName, CancellationToken cancellationToken = default)
+        => Task.FromResult<Stream>(new MemoryStream(_blobs[blobName].Content, writable: false));
+
+    public Task<BlobMetadata> GetMetadataAsync(string blobName, CancellationToken cancellationToken = default)
+    {
+        if (!_blobs.TryGetValue(blobName, out var blob))
+            return Task.FromResult(new BlobMetadata { Exists = false });
+
+        return Task.FromResult(new BlobMetadata
+        {
+            Exists = true,
+            Tier = blob.Tier,
+            ContentLength = blob.Content.LongLength,
+            IsRehydrating = blob.IsRehydrating,
+            Metadata = new Dictionary<string, string>(blob.Metadata)
+        });
+    }
+
+    public async IAsyncEnumerable<string> ListAsync(string prefix, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var blobName in _blobs.Keys.Where(name => name.StartsWith(prefix, StringComparison.Ordinal)).OrderBy(name => name, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return blobName;
+            await Task.Yield();
+        }
+    }
+
+    public Task SetMetadataAsync(string blobName, IReadOnlyDictionary<string, string> metadata, CancellationToken cancellationToken = default)
+    {
+        var blob = _blobs[blobName];
+        _blobs[blobName] = blob with { Metadata = new Dictionary<string, string>(metadata) };
+        return Task.CompletedTask;
+    }
+
+    public Task SetTierAsync(string blobName, BlobTier tier, CancellationToken cancellationToken = default)
+    {
+        var blob = _blobs[blobName];
+        _blobs[blobName] = blob with { Tier = tier };
+        return Task.CompletedTask;
+    }
+
+    public Task CopyAsync(string sourceBlobName, string destinationBlobName, BlobTier destinationTier, RehydratePriority? rehydratePriority = null, CancellationToken cancellationToken = default)
+    {
+        var source = _blobs[sourceBlobName];
+        _blobs[destinationBlobName] = source with { Tier = destinationTier, IsRehydrating = false };
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(string blobName, CancellationToken cancellationToken = default)
+    {
+        _blobs.TryRemove(blobName, out _);
+        return Task.CompletedTask;
+    }
+
+    private sealed record StoredBlob(
+        byte[] Content,
+        Dictionary<string, string> Metadata,
+        BlobTier? Tier,
+        string? ContentType,
+        bool IsRehydrating);
+
+    private sealed class CommitOnDisposeStream(Action<byte[]> onCommit) : MemoryStream
+    {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                onCommit(ToArray());
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Arius.Core.Tests/Shared/ChunkIndex/ChunkIndexServiceTests.cs
+++ b/src/Arius.Core.Tests/Shared/ChunkIndex/ChunkIndexServiceTests.cs
@@ -1,0 +1,133 @@
+using Arius.Core.Shared;
+using Arius.Core.Shared.ChunkIndex;
+using Arius.Core.Shared.Encryption;
+using Arius.Core.Tests.Shared.ChunkIndex.Fakes;
+using TUnit.Core;
+
+namespace Arius.Core.Tests.Shared.ChunkIndex;
+
+public class ChunkIndexServiceTests
+{
+    private static readonly PlaintextPassthroughService s_encryption = new();
+
+    [Test]
+    public async Task FlushAsync_MultiplePrefixes_UsesParallelUploads()
+    {
+        const string account = "acct-ci-parallel";
+        var container = $"ctr-ci-parallel-{Guid.NewGuid():N}";
+        CleanupRepo(account, container);
+
+        try
+        {
+            var blobs = new RecordingChunkIndexBlobContainerService(TimeSpan.FromMilliseconds(150));
+            var service = new ChunkIndexService(blobs, s_encryption, account, container);
+
+            service.AddEntry(new ShardEntry("aaaa" + new string('1', 60), "chunk-a", 10, 5));
+            service.AddEntry(new ShardEntry("bbbb" + new string('2', 60), "chunk-b", 20, 8));
+            service.AddEntry(new ShardEntry("cccc" + new string('3', 60), "chunk-c", 30, 12));
+
+            await service.FlushAsync();
+
+            blobs.MaxConcurrentChunkIndexUploads.ShouldBeGreaterThan(1);
+        }
+        finally
+        {
+            CleanupRepo(account, container);
+        }
+    }
+
+    [Test]
+    public async Task FlushAsync_UpdatesL1AndL2Caches_AndMergesExistingShardContent()
+    {
+        const string account = "acct-ci-cache";
+        var container = $"ctr-ci-cache-{Guid.NewGuid():N}";
+        CleanupRepo(account, container);
+
+        try
+        {
+            var blobs = new RecordingChunkIndexBlobContainerService();
+            var seedService = new ChunkIndexService(blobs, s_encryption, account, container);
+            var existingEntry = new ShardEntry("aaaa" + new string('0', 60), "chunk-existing", 100, 50);
+            seedService.AddEntry(existingEntry);
+            await seedService.FlushAsync();
+
+            CleanupRepo(account, container);
+
+            var service = new ChunkIndexService(blobs, s_encryption, account, container);
+            var newEntry = new ShardEntry("aaaa" + new string('1', 60), "chunk-new", 200, 75);
+            service.AddEntry(newEntry);
+
+            await service.FlushAsync();
+
+            var metadataReadsBeforeL1 = blobs.ChunkIndexMetadataReads;
+            var downloadsBeforeL1 = blobs.ChunkIndexDownloads;
+
+            var mergedLookup = await service.LookupAsync(existingEntry.ContentHash);
+
+            mergedLookup.ShouldNotBeNull();
+            mergedLookup.ChunkHash.ShouldBe(existingEntry.ChunkHash);
+            blobs.ChunkIndexMetadataReads.ShouldBe(metadataReadsBeforeL1);
+            blobs.ChunkIndexDownloads.ShouldBe(downloadsBeforeL1);
+
+            var l2Path = Path.Combine(RepositoryPaths.GetChunkIndexCacheDirectory(account, container), Shard.PrefixOf(existingEntry.ContentHash));
+            File.Exists(l2Path).ShouldBeTrue();
+
+            var metadataReadsBeforeL2 = blobs.ChunkIndexMetadataReads;
+            var downloadsBeforeL2 = blobs.ChunkIndexDownloads;
+            var newService = new ChunkIndexService(blobs, s_encryption, account, container);
+
+            var l2Lookup = await newService.LookupAsync(newEntry.ContentHash);
+
+            l2Lookup.ShouldNotBeNull();
+            l2Lookup.ChunkHash.ShouldBe(newEntry.ChunkHash);
+            blobs.ChunkIndexMetadataReads.ShouldBe(metadataReadsBeforeL2);
+            blobs.ChunkIndexDownloads.ShouldBe(downloadsBeforeL2);
+        }
+        finally
+        {
+            CleanupRepo(account, container);
+        }
+    }
+
+    [Test]
+    public async Task FlushAsync_ReportsProgress_PerCompletedPrefix()
+    {
+        const string account = "acct-ci-progress";
+        var container = $"ctr-ci-progress-{Guid.NewGuid():N}";
+        CleanupRepo(account, container);
+
+        try
+        {
+            var blobs = new RecordingChunkIndexBlobContainerService();
+            var service = new ChunkIndexService(blobs, s_encryption, account, container);
+            var updates = new List<(int Completed, int Total)>();
+            var progress = new SynchronousProgress<(int Completed, int Total)>(update => updates.Add(update));
+
+            service.AddEntry(new ShardEntry("aaaa" + new string('1', 60), "chunk-a", 10, 5));
+            service.AddEntry(new ShardEntry("bbbb" + new string('2', 60), "chunk-b", 20, 8));
+            service.AddEntry(new ShardEntry("cccc" + new string('3', 60), "chunk-c", 30, 12));
+
+            await service.FlushAsync(progress);
+
+            updates.Count.ShouldBe(3);
+            updates.Select(u => u.Total).Distinct().ShouldBe([3]);
+            updates.Select(u => u.Completed).OrderBy(x => x).ShouldBe([1, 2, 3]);
+        }
+        finally
+        {
+            CleanupRepo(account, container);
+        }
+    }
+
+    private static void CleanupRepo(string account, string container)
+    {
+        var repoDir = RepositoryPaths.GetRepositoryDirectory(account, container);
+        if (Directory.Exists(repoDir))
+            Directory.Delete(repoDir, recursive: true);
+    }
+
+    private sealed class SynchronousProgress<T>(Action<T> onReport) : IProgress<T>
+    {
+        public void Report(T value) => onReport(value);
+    }
+}

--- a/src/Arius.Core.Tests/Shared/ChunkIndex/Fakes/RecordingChunkIndexBlobContainerService.cs
+++ b/src/Arius.Core.Tests/Shared/ChunkIndex/Fakes/RecordingChunkIndexBlobContainerService.cs
@@ -1,0 +1,150 @@
+using System.Collections.Concurrent;
+using Arius.Core.Shared.Storage;
+
+namespace Arius.Core.Tests.Shared.ChunkIndex.Fakes;
+
+internal sealed class RecordingChunkIndexBlobContainerService : IBlobContainerService
+{
+    private readonly ConcurrentDictionary<string, StoredBlob> _blobs = new(StringComparer.Ordinal);
+    private readonly TimeSpan _chunkIndexUploadDelay;
+
+    private int _activeChunkIndexUploads;
+    private int _maxConcurrentChunkIndexUploads;
+    private int _chunkIndexMetadataReads;
+    private int _chunkIndexDownloads;
+
+    public RecordingChunkIndexBlobContainerService(TimeSpan? chunkIndexUploadDelay = null)
+    {
+        _chunkIndexUploadDelay = chunkIndexUploadDelay ?? TimeSpan.Zero;
+    }
+
+    public int MaxConcurrentChunkIndexUploads => Volatile.Read(ref _maxConcurrentChunkIndexUploads);
+    public int ChunkIndexMetadataReads => Volatile.Read(ref _chunkIndexMetadataReads);
+    public int ChunkIndexDownloads => Volatile.Read(ref _chunkIndexDownloads);
+
+    public Task CreateContainerIfNotExistsAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public async Task UploadAsync(string blobName, Stream content, IReadOnlyDictionary<string, string> metadata, BlobTier tier, string? contentType = null, bool overwrite = false, CancellationToken cancellationToken = default)
+    {
+        var isChunkIndex = blobName.StartsWith(BlobPaths.ChunkIndex, StringComparison.Ordinal);
+        if (isChunkIndex)
+        {
+            var active = Interlocked.Increment(ref _activeChunkIndexUploads);
+            UpdateMaxConcurrency(active);
+            if (_chunkIndexUploadDelay > TimeSpan.Zero)
+                await Task.Delay(_chunkIndexUploadDelay, cancellationToken);
+        }
+
+        try
+        {
+            await using var ms = new MemoryStream();
+            await content.CopyToAsync(ms, cancellationToken);
+            _blobs[blobName] = new StoredBlob(ms.ToArray(), new Dictionary<string, string>(metadata), tier, contentType, false);
+        }
+        finally
+        {
+            if (isChunkIndex)
+                Interlocked.Decrement(ref _activeChunkIndexUploads);
+        }
+    }
+
+    public Task<Stream> OpenWriteAsync(string blobName, string? contentType = null, CancellationToken cancellationToken = default)
+        => Task.FromResult<Stream>(new CommitOnDisposeStream(bytes =>
+        {
+            _blobs[blobName] = new StoredBlob(bytes, new Dictionary<string, string>(), null, contentType, false);
+        }));
+
+    public Task<Stream> DownloadAsync(string blobName, CancellationToken cancellationToken = default)
+    {
+        if (blobName.StartsWith(BlobPaths.ChunkIndex, StringComparison.Ordinal))
+            Interlocked.Increment(ref _chunkIndexDownloads);
+
+        return Task.FromResult<Stream>(new MemoryStream(_blobs[blobName].Content, writable: false));
+    }
+
+    public Task<BlobMetadata> GetMetadataAsync(string blobName, CancellationToken cancellationToken = default)
+    {
+        if (blobName.StartsWith(BlobPaths.ChunkIndex, StringComparison.Ordinal))
+            Interlocked.Increment(ref _chunkIndexMetadataReads);
+
+        if (!_blobs.TryGetValue(blobName, out var blob))
+            return Task.FromResult(new BlobMetadata { Exists = false });
+
+        return Task.FromResult(new BlobMetadata
+        {
+            Exists = true,
+            Tier = blob.Tier,
+            ContentLength = blob.Content.LongLength,
+            IsRehydrating = blob.IsRehydrating,
+            Metadata = new Dictionary<string, string>(blob.Metadata)
+        });
+    }
+
+    public async IAsyncEnumerable<string> ListAsync(string prefix, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var blobName in _blobs.Keys.Where(name => name.StartsWith(prefix, StringComparison.Ordinal)).OrderBy(name => name, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return blobName;
+            await Task.Yield();
+        }
+    }
+
+    public Task SetMetadataAsync(string blobName, IReadOnlyDictionary<string, string> metadata, CancellationToken cancellationToken = default)
+    {
+        var blob = _blobs[blobName];
+        _blobs[blobName] = blob with { Metadata = new Dictionary<string, string>(metadata) };
+        return Task.CompletedTask;
+    }
+
+    public Task SetTierAsync(string blobName, BlobTier tier, CancellationToken cancellationToken = default)
+    {
+        var blob = _blobs[blobName];
+        _blobs[blobName] = blob with { Tier = tier };
+        return Task.CompletedTask;
+    }
+
+    public Task CopyAsync(string sourceBlobName, string destinationBlobName, BlobTier destinationTier, RehydratePriority? rehydratePriority = null, CancellationToken cancellationToken = default)
+    {
+        var source = _blobs[sourceBlobName];
+        _blobs[destinationBlobName] = source with { Tier = destinationTier, IsRehydrating = false };
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(string blobName, CancellationToken cancellationToken = default)
+    {
+        _blobs.TryRemove(blobName, out _);
+        return Task.CompletedTask;
+    }
+
+    private void UpdateMaxConcurrency(int active)
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _maxConcurrentChunkIndexUploads);
+            if (active <= current)
+                return;
+
+            if (Interlocked.CompareExchange(ref _maxConcurrentChunkIndexUploads, active, current) == current)
+                return;
+        }
+    }
+
+    private sealed record StoredBlob(
+        byte[] Content,
+        Dictionary<string, string> Metadata,
+        BlobTier? Tier,
+        string? ContentType,
+        bool IsRehydrating);
+
+    private sealed class CommitOnDisposeStream(Action<byte[]> onCommit) : MemoryStream
+    {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                onCommit(ToArray());
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Arius.Core.Tests/Shared/FileTree/Fakes/RecordingFileTreeBlobContainerService.cs
+++ b/src/Arius.Core.Tests/Shared/FileTree/Fakes/RecordingFileTreeBlobContainerService.cs
@@ -1,0 +1,157 @@
+using System.Collections.Concurrent;
+using Arius.Core.Shared.Storage;
+
+namespace Arius.Core.Tests.Shared.FileTree.Fakes;
+
+internal sealed class RecordingFileTreeBlobContainerService : IBlobContainerService
+{
+    private readonly ConcurrentDictionary<string, StoredBlob> _blobs = new(StringComparer.Ordinal);
+    private readonly TimeSpan _fileTreeUploadDelay;
+    private readonly TaskCompletionSource _firstFileTreeUploadStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _allowFileTreeUploads = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly bool _blockFileTreeUploads;
+    private readonly bool _throwOnFileTreeUpload;
+
+    private int _activeFileTreeUploads;
+    private int _maxConcurrentFileTreeUploads;
+
+    public RecordingFileTreeBlobContainerService(TimeSpan? fileTreeUploadDelay = null, bool blockFileTreeUploads = false, bool throwOnFileTreeUpload = false)
+    {
+        _fileTreeUploadDelay = fileTreeUploadDelay ?? TimeSpan.Zero;
+        _blockFileTreeUploads = blockFileTreeUploads;
+        _throwOnFileTreeUpload = throwOnFileTreeUpload;
+
+        if (!blockFileTreeUploads)
+            _allowFileTreeUploads.TrySetResult();
+    }
+
+    public int MaxConcurrentFileTreeUploads => Volatile.Read(ref _maxConcurrentFileTreeUploads);
+    public Task FirstFileTreeUploadStarted => _firstFileTreeUploadStarted.Task;
+
+    public void AllowFileTreeUploads() => _allowFileTreeUploads.TrySetResult();
+
+    public Task CreateContainerIfNotExistsAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public async Task UploadAsync(string blobName, Stream content, IReadOnlyDictionary<string, string> metadata, BlobTier tier, string? contentType = null, bool overwrite = false, CancellationToken cancellationToken = default)
+    {
+        if (!overwrite && _blobs.ContainsKey(blobName))
+            throw new BlobAlreadyExistsException(blobName);
+
+        var isFileTree = blobName.StartsWith(BlobPaths.FileTrees, StringComparison.Ordinal);
+        if (isFileTree)
+        {
+            _firstFileTreeUploadStarted.TrySetResult();
+            var active = Interlocked.Increment(ref _activeFileTreeUploads);
+            UpdateMaxConcurrency(active);
+            await _allowFileTreeUploads.Task.WaitAsync(cancellationToken);
+            if (_throwOnFileTreeUpload)
+                throw new IOException("Simulated filetree upload failure");
+            if (_fileTreeUploadDelay > TimeSpan.Zero)
+                await Task.Delay(_fileTreeUploadDelay, cancellationToken);
+        }
+
+        try
+        {
+            await using var ms = new MemoryStream();
+            await content.CopyToAsync(ms, cancellationToken);
+            _blobs[blobName] = new StoredBlob(ms.ToArray(), new Dictionary<string, string>(metadata), tier, contentType, false);
+        }
+        finally
+        {
+            if (isFileTree)
+                Interlocked.Decrement(ref _activeFileTreeUploads);
+        }
+    }
+
+    public Task<Stream> OpenWriteAsync(string blobName, string? contentType = null, CancellationToken cancellationToken = default)
+        => Task.FromResult<Stream>(new CommitOnDisposeStream(bytes =>
+        {
+            _blobs[blobName] = new StoredBlob(bytes, new Dictionary<string, string>(), null, contentType, false);
+        }));
+
+    public Task<Stream> DownloadAsync(string blobName, CancellationToken cancellationToken = default)
+        => Task.FromResult<Stream>(new MemoryStream(_blobs[blobName].Content, writable: false));
+
+    public Task<BlobMetadata> GetMetadataAsync(string blobName, CancellationToken cancellationToken = default)
+    {
+        if (!_blobs.TryGetValue(blobName, out var blob))
+            return Task.FromResult(new BlobMetadata { Exists = false });
+
+        return Task.FromResult(new BlobMetadata
+        {
+            Exists = true,
+            Tier = blob.Tier,
+            ContentLength = blob.Content.LongLength,
+            IsRehydrating = blob.IsRehydrating,
+            Metadata = new Dictionary<string, string>(blob.Metadata)
+        });
+    }
+
+    public async IAsyncEnumerable<string> ListAsync(string prefix, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var blobName in _blobs.Keys.Where(name => name.StartsWith(prefix, StringComparison.Ordinal)).OrderBy(name => name, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return blobName;
+            await Task.Yield();
+        }
+    }
+
+    public Task SetMetadataAsync(string blobName, IReadOnlyDictionary<string, string> metadata, CancellationToken cancellationToken = default)
+    {
+        var blob = _blobs[blobName];
+        _blobs[blobName] = blob with { Metadata = new Dictionary<string, string>(metadata) };
+        return Task.CompletedTask;
+    }
+
+    public Task SetTierAsync(string blobName, BlobTier tier, CancellationToken cancellationToken = default)
+    {
+        var blob = _blobs[blobName];
+        _blobs[blobName] = blob with { Tier = tier };
+        return Task.CompletedTask;
+    }
+
+    public Task CopyAsync(string sourceBlobName, string destinationBlobName, BlobTier destinationTier, RehydratePriority? rehydratePriority = null, CancellationToken cancellationToken = default)
+    {
+        var source = _blobs[sourceBlobName];
+        _blobs[destinationBlobName] = source with { Tier = destinationTier, IsRehydrating = false };
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(string blobName, CancellationToken cancellationToken = default)
+    {
+        _blobs.TryRemove(blobName, out _);
+        return Task.CompletedTask;
+    }
+
+    private void UpdateMaxConcurrency(int active)
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _maxConcurrentFileTreeUploads);
+            if (active <= current)
+                return;
+
+            if (Interlocked.CompareExchange(ref _maxConcurrentFileTreeUploads, active, current) == current)
+                return;
+        }
+    }
+
+    private sealed record StoredBlob(
+        byte[] Content,
+        Dictionary<string, string> Metadata,
+        BlobTier? Tier,
+        string? ContentType,
+        bool IsRehydrating);
+
+    private sealed class CommitOnDisposeStream(Action<byte[]> onCommit) : MemoryStream
+    {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                onCommit(ToArray());
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Arius.Core.Tests/Shared/FileTree/FileTreeBuilderTests.cs
+++ b/src/Arius.Core.Tests/Shared/FileTree/FileTreeBuilderTests.cs
@@ -3,6 +3,7 @@ using Arius.Core.Shared.Encryption;
 using Arius.Core.Shared.FileTree;
 using Arius.Core.Shared.Storage;
 using Arius.Core.Tests.Fakes;
+using Arius.Core.Tests.Shared.FileTree.Fakes;
 
 namespace Arius.Core.Tests.Shared.FileTree;
 
@@ -177,5 +178,117 @@ public class FileTreeBuilderTests
             if (Directory.Exists(cacheDir))
                 Directory.Delete(cacheDir, recursive: true);
         }
+    }
+
+    [Test]
+    public async Task BuildAsync_MultipleMissingTrees_UsesParallelUploads()
+    {
+        const string acct = "acct-tree-parallel";
+        const string cont = "cont-tree-parallel";
+        var cacheDir = FileTreeService.GetDiskCacheDirectory(acct, cont);
+
+        if (Directory.Exists(cacheDir)) Directory.Delete(cacheDir, recursive: true);
+
+        var manifestPath = Path.GetTempFileName();
+        try
+        {
+            var now = new DateTimeOffset(2024, 6, 15, 10, 0, 0, TimeSpan.Zero);
+            var lines = new[]
+            {
+                new ManifestEntry("photos/2024/june/a.jpg", "hash1", now, now).Serialize(),
+                new ManifestEntry("photos/2024/june/b.jpg", "hash2", now, now).Serialize(),
+                new ManifestEntry("docs/report.pdf", "hash3", now, now).Serialize(),
+            };
+            await File.WriteAllTextAsync(manifestPath, string.Join("\n", lines) + "\n");
+
+            var blobs = new RecordingFileTreeBlobContainerService(TimeSpan.FromMilliseconds(150));
+            var builder = CreateBuilder(blobs, acct, cont);
+
+            var root = await builder.BuildAsync(manifestPath);
+
+            root.ShouldNotBeNull();
+            blobs.MaxConcurrentFileTreeUploads.ShouldBeGreaterThan(1);
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+            if (Directory.Exists(cacheDir)) Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task BuildAsync_TreeUploadProgress_ReportsCompletedUploads()
+    {
+        const string acct = "acct-tree-progress";
+        const string cont = "cont-tree-progress";
+        var cacheDir = FileTreeService.GetDiskCacheDirectory(acct, cont);
+
+        if (Directory.Exists(cacheDir)) Directory.Delete(cacheDir, recursive: true);
+
+        var manifestPath = Path.GetTempFileName();
+        try
+        {
+            var now = new DateTimeOffset(2024, 6, 15, 10, 0, 0, TimeSpan.Zero);
+            var lines = new[]
+            {
+                new ManifestEntry("photos/2024/june/a.jpg", "hash1", now, now).Serialize(),
+                new ManifestEntry("photos/2024/june/b.jpg", "hash2", now, now).Serialize(),
+                new ManifestEntry("docs/report.pdf", "hash3", now, now).Serialize(),
+            };
+            await File.WriteAllTextAsync(manifestPath, string.Join("\n", lines) + "\n");
+
+            var blobs = new RecordingFileTreeBlobContainerService();
+            var builder = CreateBuilder(blobs, acct, cont);
+            var updates = new List<(int Completed, int Total)>();
+            var progress = new SynchronousProgress<(int Completed, int Total)>(update => updates.Add(update));
+
+            var root = await builder.BuildAsync(manifestPath, progress);
+
+            root.ShouldNotBeNull();
+            updates.ShouldNotBeEmpty();
+            updates.Select(u => u.Total).Distinct().Count().ShouldBe(1);
+            updates.Select(u => u.Completed).OrderBy(x => x).Last().ShouldBe(updates[0].Total);
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+            if (Directory.Exists(cacheDir)) Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task BuildAsync_FailedUpload_DoesNotPublishFinalCacheFile()
+    {
+        const string acct = "acct-tree-failure";
+        const string cont = "cont-tree-failure";
+        var cacheDir = FileTreeService.GetDiskCacheDirectory(acct, cont);
+
+        if (Directory.Exists(cacheDir)) Directory.Delete(cacheDir, recursive: true);
+
+        var manifestPath = Path.GetTempFileName();
+        try
+        {
+            var now = new DateTimeOffset(2024, 6, 15, 10, 0, 0, TimeSpan.Zero);
+            await File.WriteAllTextAsync(manifestPath,
+                new ManifestEntry("readme.txt", "aabbccdd", now, now).Serialize() + "\n");
+
+            var blobs = new RecordingFileTreeBlobContainerService(throwOnFileTreeUpload: true);
+            var builder = CreateBuilder(blobs, acct, cont);
+
+            await Should.ThrowAsync<IOException>(() => builder.BuildAsync(manifestPath));
+
+            Directory.Exists(cacheDir).ShouldBeTrue();
+            Directory.EnumerateFiles(cacheDir).ShouldBeEmpty();
+        }
+        finally
+        {
+            File.Delete(manifestPath);
+            if (Directory.Exists(cacheDir)) Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    private sealed class SynchronousProgress<T>(Action<T> onReport) : IProgress<T>
+    {
+        public void Report(T value) => onReport(value);
     }
 }

--- a/src/Arius.Core/Features/ArchiveCommand/ArchiveCommandHandler.cs
+++ b/src/Arius.Core/Features/ArchiveCommand/ArchiveCommandHandler.cs
@@ -472,19 +472,32 @@ public sealed class ArchiveCommandHandler : ICommandHandler<ArchiveCommand, Arch
 
             // ── End-of-pipeline ───────────────────────────────────────────────
 
-            // Task 5.1: Validate the filetree service before building the tree.
-            await _fileTreeService.ValidateAsync(cancellationToken);
-
-            // Task 8.10: Index flush
-            await _chunkIndex.FlushAsync(cancellationToken);
-            _logger.LogInformation("[index] Flush complete");
-
-            // Task 8.11: Sort manifest → build tree → create snapshot
+            // Task 8.10 / 8.11: overlap independent finalization work.
             await manifestWriter.DisposeAsync();
-            await ManifestSorter.SortAsync(manifestPath, cancellationToken);
 
-            var treeBuilder = new FileTreeBuilder(_encryption, _fileTreeService);
-            var rootHash    = await treeBuilder.BuildAsync(manifestPath, cancellationToken);
+            var flushTask = Task.Run(async () =>
+            {
+                var flushProgress = new Progress<(int Completed, int Total)>(update =>
+                    _mediator.Publish(new ChunkIndexFlushProgressEvent(update.Completed, update.Total), cancellationToken).AsTask().GetAwaiter().GetResult());
+
+                await _chunkIndex.FlushAsync(flushProgress, cancellationToken);
+                _logger.LogInformation("[index] Flush complete");
+            }, cancellationToken);
+
+            var treeTask = Task.Run(async () =>
+            {
+                await ManifestSorter.SortAsync(manifestPath, cancellationToken);
+
+                var treeBuilder = new FileTreeBuilder(_encryption, _fileTreeService);
+                var treeProgress = new Progress<(int Completed, int Total)>(update =>
+                    _mediator.Publish(new TreeUploadProgressEvent(update.Completed, update.Total), cancellationToken).AsTask().GetAwaiter().GetResult());
+
+                return await treeBuilder.BuildAsync(manifestPath, treeProgress, cancellationToken);
+            }, cancellationToken);
+
+            await Task.WhenAll(flushTask, treeTask);
+
+            var rootHash = await treeTask;
             _logger.LogInformation("[tree] Build complete: rootHash={RootHash}", rootHash is not null ? rootHash[..8] : "(none)");
 
             string?        snapshotRootHash = null;

--- a/src/Arius.Core/Features/ArchiveCommand/Events.cs
+++ b/src/Arius.Core/Features/ArchiveCommand/Events.cs
@@ -38,6 +38,12 @@ public sealed record TarBundleSealingEvent(int EntryCount, long UncompressedSize
 /// <summary>A tar bundle was uploaded.</summary>
 public sealed record TarBundleUploadedEvent(string TarHash, long CompressedSize, int EntryCount) : INotification;
 
+/// <summary>Chunk-index flush progress update.</summary>
+public sealed record ChunkIndexFlushProgressEvent(int ShardsCompleted, int TotalShards) : INotification;
+
+/// <summary>Filetree upload progress update.</summary>
+public sealed record TreeUploadProgressEvent(int BlobsUploaded, int TotalBlobs) : INotification;
+
 /// <summary>Snapshot creation complete.</summary>
 public sealed record SnapshotCreatedEvent(string RootHash, DateTimeOffset Timestamp, long FileCount) : INotification;
 

--- a/src/Arius.Core/Shared/ChunkIndex/ChunkIndexService.cs
+++ b/src/Arius.Core/Shared/ChunkIndex/ChunkIndexService.cs
@@ -20,6 +20,7 @@ public sealed class ChunkIndexService : IDisposable
     // ── Configuration ─────────────────────────────────────────────────────────
 
     public const long DefaultCacheBudgetBytes = 512L * 1024 * 1024; // 512 MB
+    private const int FlushWorkers = 32;
 
     // ── Dependencies ──────────────────────────────────────────────────────────
 
@@ -138,46 +139,57 @@ public sealed class ChunkIndexService : IDisposable
     /// Merges all pending entries into existing shards and uploads changed shards.
     /// Should be called once at the end of an archive run.
     /// </summary>
-    public async Task FlushAsync(CancellationToken cancellationToken = default)
+    public async Task FlushAsync(IProgress<(int Completed, int Total)>? progress = null, CancellationToken cancellationToken = default)
     {
         if (_pendingEntries.IsEmpty) 
             return;
 
-        // Group pending entries by shard prefix
-        var byPrefix = _pendingEntries.GroupBy(e => Shard.PrefixOf(e.ContentHash));
+        // Snapshot and clear pending before launching workers so this flush operation has a
+        // stable prefix set and new entries recorded later are left for the next flush.
+        var pending = new List<ShardEntry>();
+        while (_pendingEntries.TryTake(out var entry))
+            pending.Add(entry);
 
-        foreach (var group in byPrefix)
-        {
-            var prefix   = group.Key;
-            var existing = await LoadShardAsync(prefix, cancellationToken);
-            var merged   = existing.Merge(group);
+        var byPrefix = pending
+            .GroupBy(e => Shard.PrefixOf(e.ContentHash))
+            .Select(group => (Prefix: group.Key, Entries: group.ToList()))
+            .ToList();
 
-            // Serialize and upload
-            var bytes    = await ShardSerializer.SerializeAsync(merged, _encryption, cancellationToken);
-            var blobName = BlobPaths.ChunkIndexShard(prefix);
+        var total = byPrefix.Count;
+        var completed = 0;
 
-            await _blobs.UploadAsync(
-                blobName: blobName,
-                content: new MemoryStream(bytes),
-                metadata: new Dictionary<string, string>(),
-                tier: BlobTier.Cool,
-                contentType: _encryption.IsEncrypted
-                    ? ContentTypes.ChunkIndexGcmEncrypted
-                    : ContentTypes.ChunkIndexPlaintext,
-                overwrite: true,
-                cancellationToken: cancellationToken);
+        await Parallel.ForEachAsync(
+            byPrefix,
+            new ParallelOptions { MaxDegreeOfParallelism = FlushWorkers, CancellationToken = cancellationToken },
+            async (group, ct) =>
+            {
+                var existing = await LoadShardAsync(group.Prefix, ct);
+                var merged   = existing.Merge(group.Entries);
 
-            // Save to L2 disk cache (plaintext, no gzip/encryption)
-            SaveToL2(prefix, merged);
+                // Serialize and upload
+                var bytes    = await ShardSerializer.SerializeAsync(merged, _encryption, ct);
+                var blobName = BlobPaths.ChunkIndexShard(group.Prefix);
 
-            // Promote merged shard to L1
-            PromoteToL1(prefix, merged, bytes.Length);
-        }
+                await _blobs.UploadAsync(
+                    blobName: blobName,
+                    content: new MemoryStream(bytes),
+                    metadata: new Dictionary<string, string>(),
+                    tier: BlobTier.Cool,
+                    contentType: _encryption.IsEncrypted
+                        ? ContentTypes.ChunkIndexGcmEncrypted
+                        : ContentTypes.ChunkIndexPlaintext,
+                    overwrite: true,
+                    cancellationToken: ct);
 
-        // Clear pending
-        while (_pendingEntries.TryTake(out _))
-        {
-        }
+                // Save to L2 disk cache (plaintext, no gzip/encryption)
+                SaveToL2(group.Prefix, merged);
+
+                // Promote merged shard to L1
+                PromoteToL1(group.Prefix, merged, bytes.Length);
+
+                var done = Interlocked.Increment(ref completed);
+                progress?.Report((done, total));
+            });
     }
 
     // ── Tier resolution ───────────────────────────────────────────────────────

--- a/src/Arius.Core/Shared/FileTree/FileTreeBuilder.cs
+++ b/src/Arius.Core/Shared/FileTree/FileTreeBuilder.cs
@@ -1,4 +1,6 @@
 using Arius.Core.Shared.Encryption;
+using System.Collections.Concurrent;
+using System.Threading.Channels;
 
 namespace Arius.Core.Shared.FileTree;
 
@@ -21,6 +23,9 @@ namespace Arius.Core.Shared.FileTree;
 /// </summary>
 public sealed class FileTreeBuilder
 {
+    private const int UploadWorkers = 32;
+    private const int UploadQueueCapacity = 128;
+
     private readonly IEncryptionService  _encryption;
     private readonly FileTreeService    _fileTreeService;
 
@@ -43,126 +48,189 @@ public sealed class FileTreeBuilder
     /// </summary>
     public async Task<string?> BuildAsync(
         string            sortedManifestPath,
+        IProgress<(int Completed, int Total)>? progress,
         CancellationToken cancellationToken = default)
     {
         // Ensure cache is validated before calling ExistsInRemote (idempotent — no-op if already validated).
         await _fileTreeService.ValidateAsync(cancellationToken);
 
-        // Accumulated directory entries keyed by directory path (forward-slash, no trailing slash)
-        // Value: list of FileTreeEntry for that directory (files + resolved child dirs)
-        var dirEntries = new Dictionary<string, List<FileTreeEntry>>(StringComparer.Ordinal);
+        var uploadChannel = Channel.CreateBounded<PendingTreeUpload>(UploadQueueCapacity);
+        var totalUploadsKnown = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var bufferedProgress = new ConcurrentQueue<int>();
+        var spoolPaths = new ConcurrentBag<string>();
+        var uploadsQueued = 0;
+        var uploadsCompleted = 0;
 
-        // Stream through sorted manifest entries
-        await foreach (var manifestEntry in ReadManifestAsync(sortedManifestPath, cancellationToken))
-        {
-            var filePath = manifestEntry.Path;  // e.g., "photos/2024/june/a.jpg"
-            var dirPath  = GetDirectoryPath(filePath);  // e.g., "photos/2024/june"
-            var name     = Path.GetFileName(filePath);
-
-            if (!dirEntries.TryGetValue(dirPath, out var list))
-                dirEntries[dirPath] = list = new List<FileTreeEntry>();
-
-            list.Add(new FileTreeEntry
+        var consumers = Enumerable.Range(0, UploadWorkers)
+            .Select(_ => Task.Run(async () =>
             {
-                Name     = name,
-                Type     = FileTreeEntryType.File,
-                Hash     = manifestEntry.ContentHash,
-                Created  = manifestEntry.Created,
-                Modified = manifestEntry.Modified
-            });
-        }
-
-        if (dirEntries.Count == 0) return null;
-
-        // Ensure all intermediate directories exist in dirEntries
-        // (directories that only contain subdirectories, not files, would otherwise be missing)
-        var allDirs = new HashSet<string>(dirEntries.Keys, StringComparer.Ordinal);
-        foreach (var dirPath in dirEntries.Keys.ToList())
-        {
-            var parent = GetDirectoryPath(dirPath);
-            while (parent != string.Empty && !allDirs.Contains(parent))
-            {
-                allDirs.Add(parent);
-                dirEntries[parent] = new List<FileTreeEntry>();
-                parent = GetDirectoryPath(parent);
-            }
-        }
-
-        // Process directories bottom-up: deepest paths first (more slashes → deeper)
-        var sortedDirs = dirEntries.Keys
-            .OrderByDescending(d => d.Count(c => c == '/'))
-            .ThenByDescending(d => d, StringComparer.Ordinal)
-            .ToList();
-
-        // Map from directory path → its computed tree hash (for cascading to parents)
-        var dirHashMap = new Dictionary<string, string>(StringComparer.Ordinal);
-
-        string? rootHash = null;
-
-        foreach (var dirPath in sortedDirs)
-        {
-            var entries = dirEntries[dirPath];
-
-            // Inject already-computed child directory entries
-            // (any immediate child directories of dirPath that have been processed)
-            foreach (var (childDirPath, childHash) in dirHashMap)
-            {
-                var childParent = GetDirectoryPath(childDirPath);
-                if (childParent == dirPath)
+                await foreach (var upload in uploadChannel.Reader.ReadAllAsync(cancellationToken))
                 {
-                    var childName = GetLastSegment(childDirPath);
-                    entries.Add(new FileTreeEntry
+                    try
                     {
-                        Name     = childName + "/",
-                        Type     = FileTreeEntryType.Dir,
-                        Hash     = childHash,
-                        Created  = null,
-                        Modified = null
-                    });
+                        var plaintext = await File.ReadAllBytesAsync(upload.SpoolPath, cancellationToken);
+                        var tree = FileTreeBlobSerializer.Deserialize(plaintext);
+                        await _fileTreeService.WriteAsync(upload.Hash, tree, cancellationToken);
+
+                        var done = Interlocked.Increment(ref uploadsCompleted);
+                        if (progress is not null)
+                        {
+                            if (totalUploadsKnown.Task.IsCompletedSuccessfully)
+                                progress.Report((done, totalUploadsKnown.Task.Result));
+                            else
+                                bufferedProgress.Enqueue(done);
+                        }
+                    }
+                    finally
+                    {
+                        try { File.Delete(upload.SpoolPath); } catch { /* best-effort cleanup */ }
+                    }
+                }
+            }, cancellationToken))
+            .ToArray();
+
+        try
+        {
+            // Accumulated directory entries keyed by directory path (forward-slash, no trailing slash)
+            // Value: list of FileTreeEntry for that directory (files + resolved child dirs)
+            var dirEntries = new Dictionary<string, List<FileTreeEntry>>(StringComparer.Ordinal);
+
+            // Stream through sorted manifest entries
+            await foreach (var manifestEntry in ReadManifestAsync(sortedManifestPath, cancellationToken))
+            {
+                var filePath = manifestEntry.Path;  // e.g., "photos/2024/june/a.jpg"
+                var dirPath  = GetDirectoryPath(filePath);  // e.g., "photos/2024/june"
+                var name     = Path.GetFileName(filePath);
+
+                if (!dirEntries.TryGetValue(dirPath, out var list))
+                    dirEntries[dirPath] = list = new List<FileTreeEntry>();
+
+                list.Add(new FileTreeEntry
+                {
+                    Name     = name,
+                    Type     = FileTreeEntryType.File,
+                    Hash     = manifestEntry.ContentHash,
+                    Created  = manifestEntry.Created,
+                    Modified = manifestEntry.Modified
+                });
+            }
+
+            if (dirEntries.Count == 0)
+            {
+                uploadChannel.Writer.Complete();
+                totalUploadsKnown.TrySetResult(0);
+                return null;
+            }
+
+            // Ensure all intermediate directories exist in dirEntries
+            // (directories that only contain subdirectories, not files, would otherwise be missing)
+            var allDirs = new HashSet<string>(dirEntries.Keys, StringComparer.Ordinal);
+            foreach (var dirPath in dirEntries.Keys.ToList())
+            {
+                var parent = GetDirectoryPath(dirPath);
+                while (parent != string.Empty && !allDirs.Contains(parent))
+                {
+                    allDirs.Add(parent);
+                    dirEntries[parent] = new List<FileTreeEntry>();
+                    parent = GetDirectoryPath(parent);
                 }
             }
 
-            var tree = new FileTreeBlob { Entries = entries };
-            var hash = FileTreeBlobSerializer.ComputeHash(tree, _encryption);
+            // Process directories bottom-up: deepest paths first (more slashes → deeper)
+            var sortedDirs = dirEntries.Keys
+                .OrderByDescending(d => d.Count(c => c == '/'))
+                .ThenByDescending(d => d, StringComparer.Ordinal)
+                .ToList();
 
-            // Dedup: upload only if not already cached/known remotely
-            await EnsureUploadedAsync(hash, tree, cancellationToken);
+            // Map from directory path → its computed tree hash (for cascading to parents)
+            var dirHashMap = new Dictionary<string, string>(StringComparer.Ordinal);
 
-            dirHashMap[dirPath] = hash;
+            string? rootHash = null;
 
-            // If this directory has no parent (empty string = root), it is the root
-            if (dirPath == string.Empty || !dirPath.Contains('/'))
+            foreach (var dirPath in sortedDirs)
             {
-                // Check if there's a parent for this dir
-                var parent = GetDirectoryPath(dirPath);
-                if (parent == dirPath) // root
-                    rootHash = hash;
-                // else: will be cascaded to parent when parent is processed
+                var entries = dirEntries[dirPath];
+
+                // Inject already-computed child directory entries
+                // (any immediate child directories of dirPath that have been processed)
+                foreach (var (childDirPath, childHash) in dirHashMap)
+                {
+                    var childParent = GetDirectoryPath(childDirPath);
+                    if (childParent == dirPath)
+                    {
+                        var childName = GetLastSegment(childDirPath);
+                        entries.Add(new FileTreeEntry
+                        {
+                            Name     = childName + "/",
+                            Type     = FileTreeEntryType.Dir,
+                            Hash     = childHash,
+                            Created  = null,
+                            Modified = null
+                        });
+                    }
+                }
+
+                var tree = new FileTreeBlob { Entries = entries };
+                var hash = FileTreeBlobSerializer.ComputeHash(tree, _encryption);
+
+                await QueueUploadIfNeededAsync(hash, tree, uploadChannel.Writer, spoolPaths, () => uploadsQueued++, cancellationToken);
+
+                dirHashMap[dirPath] = hash;
+
+                // If this directory has no parent (empty string = root), it is the root
+                if (dirPath == string.Empty || !dirPath.Contains('/'))
+                {
+                    // Check if there's a parent for this dir
+                    var parent = GetDirectoryPath(dirPath);
+                    if (parent == dirPath) // root
+                        rootHash = hash;
+                    // else: will be cascaded to parent when parent is processed
+                }
+            }
+
+            // The root is the directory with the shallowest path
+            // Find the directory closest to root (fewest slashes)
+            if (rootHash is null)
+            {
+                rootHash = await BuildRootBlobAsync(dirHashMap, dirEntries, uploadChannel.Writer, spoolPaths, () => uploadsQueued++, cancellationToken);
+            }
+
+            totalUploadsKnown.TrySetResult(uploadsQueued);
+            while (bufferedProgress.TryDequeue(out var done))
+                progress?.Report((done, uploadsQueued));
+
+            uploadChannel.Writer.Complete();
+            await Task.WhenAll(consumers);
+
+            return rootHash;
+        }
+        catch
+        {
+            uploadChannel.Writer.TryComplete();
+            throw;
+        }
+        finally
+        {
+            foreach (var spoolPath in spoolPaths)
+            {
+                try { File.Delete(spoolPath); } catch { /* best-effort cleanup */ }
             }
         }
-
-        // The root is the directory with the shallowest path
-        // Find the directory closest to root (fewest slashes)
-        if (rootHash is null)
-        {
-            var rootDir = dirHashMap.Keys
-                .OrderBy(d => d.Count(c => c == '/'))
-                .ThenBy(d => d, StringComparer.Ordinal)
-                .First();
-
-            // Build the root tree — all immediate children of "" (root)
-            // If all files are in subdirectories, we need to build root blob too
-            rootHash = await BuildRootBlobAsync(dirHashMap, dirEntries, cancellationToken);
-        }
-
-        return rootHash;
     }
+
+    public Task<string?> BuildAsync(
+        string            sortedManifestPath,
+        CancellationToken cancellationToken = default)
+        => BuildAsync(sortedManifestPath, progress: null, cancellationToken);
 
     // ── Private helpers ────────────────────────────────────────────────────────
 
     private async Task<string> BuildRootBlobAsync(
         Dictionary<string, string>       dirHashMap,
         Dictionary<string, List<FileTreeEntry>> dirEntries,
+        ChannelWriter<PendingTreeUpload> uploadWriter,
+        ConcurrentBag<string>            spoolPaths,
+        Action                           onQueued,
         CancellationToken                cancellationToken)
     {
         // Find top-level entries (directories/files whose parent is "")
@@ -193,20 +261,31 @@ public sealed class FileTreeBuilder
 
         var rootTree = new FileTreeBlob { Entries = rootEntryList };
         var rootHash = FileTreeBlobSerializer.ComputeHash(rootTree, _encryption);
-        await EnsureUploadedAsync(rootHash, rootTree, cancellationToken);
+        await QueueUploadIfNeededAsync(rootHash, rootTree, uploadWriter, spoolPaths, onQueued, cancellationToken);
         return rootHash;
     }
 
     /// <summary>
-    /// Uploads a tree blob via <see cref="FileTreeService"/> if not already present remotely.
+    /// Writes a tree blob to a temporary spool file for later parallel upload if it is not already
+    /// known remotely.
     /// </summary>
-    private async Task EnsureUploadedAsync(
+    private async Task QueueUploadIfNeededAsync(
         string            treeHash,
-        FileTreeBlob          tree,
+        FileTreeBlob      tree,
+        ChannelWriter<PendingTreeUpload> uploadWriter,
+        ConcurrentBag<string>            spoolPaths,
+        Action                           onQueued,
         CancellationToken cancellationToken)
     {
-        if (_fileTreeService.ExistsInRemote(treeHash)) return;
-        await _fileTreeService.WriteAsync(treeHash, tree, cancellationToken);
+        if (_fileTreeService.ExistsInRemote(treeHash))
+            return;
+
+        var plaintext = FileTreeBlobSerializer.Serialize(tree);
+        var spoolPath = Path.Combine(Path.GetTempPath(), $"arius-filetree-{Guid.NewGuid():N}.tmp");
+        await File.WriteAllBytesAsync(spoolPath, plaintext, cancellationToken);
+        spoolPaths.Add(spoolPath);
+        onQueued();
+        await uploadWriter.WriteAsync(new PendingTreeUpload(treeHash, spoolPath), cancellationToken);
     }
 
     // ── Manifest streaming ────────────────────────────────────────────────────
@@ -246,4 +325,6 @@ public sealed class FileTreeBuilder
         var idx = path.LastIndexOf('/');
         return idx < 0 ? path : path[(idx + 1)..];
     }
+
+    private sealed record PendingTreeUpload(string Hash, string SpoolPath);
 }


### PR DESCRIPTION
## Summary
- overlap archive finalization so chunk-index flush runs in parallel with manifest sort and filetree build/upload while snapshot creation still waits for both branches
- parallelize chunk-index shard flushes and refactor filetree building into a bounded disk-spooled upload pipeline with CLI progress and regression coverage for snapshot commit-point semantics
- update OpenSpec tasks plus README/AGENTS guidance to reflect durability rules and the archive-manifest versus snapshot terminology

## Testing
- dotnet test --project src/Arius.Core.Tests/Arius.Core.Tests.csproj
- dotnet test --project src/Arius.Cli.Tests/Arius.Cli.Tests.csproj
- dotnet test --project src/Arius.Integration.Tests/Arius.Integration.Tests.csproj
- dotnet test --project src/Arius.AzureBlob.Tests/Arius.AzureBlob.Tests.csproj
- dotnet test --project src/Arius.Architecture.Tests/Arius.Architecture.Tests.csproj
- dotnet test --project src/Arius.E2E.Tests/Arius.E2E.Tests.csproj