### PR TITLE
Improve Arius.Explorer test coverage

### DIFF
--- a/.slopwatch/baseline.json
+++ b/.slopwatch/baseline.json
@@ -1,0 +1,260 @@
+{
+  "version": 1,
+  "createdAt": "2026-04-19T05:58:29.8559632+00:00",
+  "updatedAt": "2026-04-19T05:58:29.8590116+00:00",
+  "description": "Initial baseline created by 'slopwatch init' on 2026-04-19 05:58:29 UTC",
+  "entries": [
+    {
+      "hash": "f842af346b93fa73",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Cli/Commands/Update/UpdateVerb.cs",
+      "lineNumber": 166,
+      "codeSnippet": "catch { /* best-effort cleanup */ }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8587205+00:00"
+    },
+    {
+      "hash": "55577880b9147b73",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Cli/Commands/Update/UpdateVerb.cs",
+      "lineNumber": 173,
+      "codeSnippet": "catch\r\n                {\r\n                }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8588265+00:00"
+    },
+    {
+      "hash": "6e5d2aad62476608",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Cli.Tests/Commands/Archive/ProgressCallbackIntegrationTests.cs",
+      "lineNumber": 11,
+      "codeSnippet": "SpinWait.SpinUntil(condition, TimeSpan.FromSeconds(1)).ShouldBeTrue()",
+      "message": "Test uses SpinWait which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8588336+00:00"
+    },
+    {
+      "hash": "47671674deb75d61",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Cli.Tests/Commands/Archive/ProgressCallbackIntegrationTests.cs",
+      "lineNumber": 11,
+      "codeSnippet": "SpinWait.SpinUntil(condition, TimeSpan.FromSeconds(1))",
+      "message": "Test uses SpinWait which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8588374+00:00"
+    },
+    {
+      "hash": "7b5eb675f49a6656",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Cli.Tests/Commands/Restore/RestoreTcsCoordinationTests.cs",
+      "lineNumber": 79,
+      "codeSnippet": "Task.Delay(50)",
+      "message": "Test uses Task.Delay(50) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8588464+00:00"
+    },
+    {
+      "hash": "09295c86822f20ae",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Cli.Tests/Commands/Restore/RestoreTcsCoordinationTests.cs",
+      "lineNumber": 87,
+      "codeSnippet": "Task.Delay(20)",
+      "message": "Test uses Task.Delay(20) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8588498+00:00"
+    },
+    {
+      "hash": "8ba82b541fd67d9b",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Cli.Tests/Commands/Restore/RestoreTcsCoordinationTests.cs",
+      "lineNumber": 103,
+      "codeSnippet": "Task.Delay(5000)",
+      "message": "Test uses Task.Delay(5000) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.858853+00:00"
+    },
+    {
+      "hash": "5d911240c1675d7c",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Core/Features/ArchiveCommand/ArchiveCommandHandler.cs",
+      "lineNumber": 461,
+      "codeSnippet": "catch { /* ignore */ }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589047+00:00"
+    },
+    {
+      "hash": "91ae2d5e6ce897e1",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Core/Features/ArchiveCommand/ArchiveCommandHandler.cs",
+      "lineNumber": 564,
+      "codeSnippet": "catch\r\n            {\r\n                /* ignore */\r\n            }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589099+00:00"
+    },
+    {
+      "hash": "581fffc590679ef4",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Core/Shared/FileTree/FileTreeService.cs",
+      "lineNumber": 134,
+      "codeSnippet": "catch { /* best-effort */ }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589137+00:00"
+    },
+    {
+      "hash": "919564589745508e",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Core/Shared/FileTree/FileTreeService.cs",
+      "lineNumber": 137,
+      "codeSnippet": "catch (FileNotFoundException)\r\n        {\r\n            // Another concurrent caller may have replaced the cache file between Exists and read.\r\n        }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589179+00:00"
+    },
+    {
+      "hash": "83ed6a19b6c99ce1",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Core/Shared/FileTree/FileTreeService.cs",
+      "lineNumber": 141,
+      "codeSnippet": "catch (DirectoryNotFoundException)\r\n        {\r\n            // Treat concurrent directory cleanup or creation races as a cache miss.\r\n        }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589234+00:00"
+    },
+    {
+      "hash": "b0ceecce9d445406",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Core/Shared/FileTree/FileTreeService.cs",
+      "lineNumber": 184,
+      "codeSnippet": "catch\r\n            {\r\n                // Best-effort temp cleanup only.\r\n            }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589272+00:00"
+    },
+    {
+      "hash": "06fa5821a2b07e55",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Core/Shared/FileTree/FileTreeService.cs",
+      "lineNumber": 216,
+      "codeSnippet": "catch (BlobAlreadyExistsException)\r\n        {\r\n            // Blob was already uploaded (crash recovery or concurrent run). Continue.\r\n        }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.858931+00:00"
+    },
+    {
+      "hash": "1768371c283e1c33",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Core/Shared/FileTree/FileTreeService.cs",
+      "lineNumber": 305,
+      "codeSnippet": "catch { /* ignore individual failures */ }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589342+00:00"
+    },
+    {
+      "hash": "2c3880b1d6517c60",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Core.Tests/Features/ArchiveCommand/ArchiveTestEnvironment.cs",
+      "lineNumber": 108,
+      "codeSnippet": "catch (DirectoryNotFoundException)\r\n        {\r\n        }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589389+00:00"
+    },
+    {
+      "hash": "72376a498d314a0a",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.E2E.Tests/RehydrationE2ETests.cs",
+      "lineNumber": 233,
+      "codeSnippet": "Task.Delay(2000, ct)",
+      "message": "Test uses Task.Delay(2000) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8589426+00:00"
+    },
+    {
+      "hash": "49d6c72110306a52",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.E2E.Tests/Fixtures/AzureFixture.cs",
+      "lineNumber": 72,
+      "codeSnippet": "catch { /* best-effort */ }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589459+00:00"
+    },
+    {
+      "hash": "10e3dbff16080806",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Explorer/ChooseRepository/ChooseRepositoryViewModel.cs",
+      "lineNumber": 159,
+      "codeSnippet": "catch (OperationCanceledException)\r\n        {\r\n            // Cancellation is expected when new credentials are entered; do not flag as error\r\n        }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589509+00:00"
+    },
+    {
+      "hash": "9cd5431125a8377c",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Explorer/ChooseRepository/ChooseRepositoryViewModel.cs",
+      "lineNumber": 238,
+      "codeSnippet": "catch (Exception)\r\n        {\r\n            // TODO: Handle error - show message to user\r\n        }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589549+00:00"
+    },
+    {
+      "hash": "6ffe7152bf85a3b1",
+      "ruleId": "SW003",
+      "filePath": "src/Arius.Explorer/RepositoryExplorer/RepositoryExplorerViewModel.cs",
+      "lineNumber": 241,
+      "codeSnippet": "catch (OperationCanceledException)\r\n        {\r\n        }",
+      "message": "Empty catch block swallows exceptions without handling",
+      "baselinedAt": "2026-04-19T05:58:29.8589586+00:00"
+    },
+    {
+      "hash": "93d1e5c2f4450dc7",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Explorer.Tests/ChooseRepository/ChooseRepositoryViewModelTests.cs",
+      "lineNumber": 230,
+      "codeSnippet": "Task.Delay(25)",
+      "message": "Test uses Task.Delay(25) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8589722+00:00"
+    },
+    {
+      "hash": "8f520324d88e9362",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Explorer.Tests/RepositoryExplorer/RepositoryExplorerViewModelTests.cs",
+      "lineNumber": 339,
+      "codeSnippet": "Task.Delay(25)",
+      "message": "Test uses Task.Delay(25) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8589761+00:00"
+    },
+    {
+      "hash": "945d54a5ae368f02",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Explorer.Tests/Settings/RecentRepositoryManagerTests.cs",
+      "lineNumber": 29,
+      "codeSnippet": "Task.Delay(5).GetAwaiter().GetResult()",
+      "message": "Test uses Task.Delay(?) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8589796+00:00"
+    },
+    {
+      "hash": "e2e16eb3c44c09ff",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Explorer.Tests/Settings/RecentRepositoryManagerTests.cs",
+      "lineNumber": 29,
+      "codeSnippet": "Task.Delay(5).GetAwaiter()",
+      "message": "Test uses Task.Delay(?) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8589828+00:00"
+    },
+    {
+      "hash": "4af1265c9ffb201d",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Explorer.Tests/Settings/RecentRepositoryManagerTests.cs",
+      "lineNumber": 29,
+      "codeSnippet": "Task.Delay(5)",
+      "message": "Test uses Task.Delay(5) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8589859+00:00"
+    },
+    {
+      "hash": "5ce9eb332da2143e",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Integration.Tests/Pipeline/ListQueryIntegrationTests.cs",
+      "lineNumber": 111,
+      "codeSnippet": "Task.Delay(1100)",
+      "message": "Test uses Task.Delay(1100) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.859008+00:00"
+    },
+    {
+      "hash": "7cf0a5e6b67e68bc",
+      "ruleId": "SW004",
+      "filePath": "src/Arius.Integration.Tests/Pipeline/RoundtripTests.cs",
+      "lineNumber": 170,
+      "codeSnippet": "Task.Delay(1100)",
+      "message": "Test uses Task.Delay(1100) which may indicate a timing-dependent test",
+      "baselinedAt": "2026-04-19T05:58:29.8590115+00:00"
+    }
+  ]
+}

--- a/.slopwatch/config.json.example
+++ b/.slopwatch/config.json.example
@@ -1,0 +1,10 @@
+{
+  "suppressions": [
+    {
+      "ruleId": "SW002",
+      "pattern": "**/Generated/**",
+      "justification": "Generated code from protobuf/gRPC compiler - cannot be modified"
+    }
+  ],
+  "globalSuppressions": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,6 @@ This project uses **TUnit** (not xUnit/NUnit). Key differences:
 - **List tests**: `dotnet test --project <path-to-csproj> --list-tests`
 - The standard `--filter` flag does NOT work with TUnit; it silently runs zero tests.
 - **Coverage with TUnit/MTP**: use `--coverage`, not `--collect:"XPlat Code Coverage"`
-- **Explorer coverage**: prefer `src/Arius.Explorer.Tests/coverage.settings.xml` so coverage reflects testable Explorer logic instead of generated `obj` code and WPF shell/bootstrap files
 
 - Use `FakeLogger<T>` from `Microsoft.Extensions.Diagnostics.Testing` instead of `NullLogger<T>` in test projects.
 - Test projects should mirror the structure of the project they exercise so intent stays obvious.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,8 @@ This project uses **TUnit** (not xUnit/NUnit). Key differences:
 - **Filter by test name**: use `--treenode-filter "/*/*/*/<TestMethodName>"`
 - **List tests**: `dotnet test --project <path-to-csproj> --list-tests`
 - The standard `--filter` flag does NOT work with TUnit; it silently runs zero tests.
+- **Coverage with TUnit/MTP**: use `--coverage`, not `--collect:"XPlat Code Coverage"`
+- **Explorer coverage**: prefer `src/Arius.Explorer.Tests/coverage.settings.xml` so coverage reflects testable Explorer logic instead of generated `obj` code and WPF shell/bootstrap files
 
 - Use `FakeLogger<T>` from `Microsoft.Extensions.Diagnostics.Testing` instead of `NullLogger<T>` in test projects.
 - Test projects should mirror the structure of the project they exercise so intent stays obvious.

--- a/src/Arius.Explorer.Tests/Arius.Explorer.Tests.csproj
+++ b/src/Arius.Explorer.Tests/Arius.Explorer.Tests.csproj
@@ -9,6 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
 		<PackageReference Include="NSubstitute" />
 		<PackageReference Include="Shouldly" />
 		<PackageReference Include="TUnit" />

--- a/src/Arius.Explorer.Tests/ChooseRepository/ChooseRepositoryViewModelTests.cs
+++ b/src/Arius.Explorer.Tests/ChooseRepository/ChooseRepositoryViewModelTests.cs
@@ -11,6 +11,7 @@ using Arius.Explorer.ChooseRepository;
 using Arius.Explorer.Settings;
 using Arius.Explorer.Shared.Extensions;
 using Mediator;
+using Microsoft.Extensions.Logging.Testing;
 using NSubstitute;
 
 namespace Arius.Explorer.Tests.ChooseRepository;
@@ -21,8 +22,9 @@ public class ChooseRepositoryViewModelTests
     public void Defaults_AreEmptyAndIdle()
     {
         var mediator = Substitute.For<IMediator>();
+        var logger = new FakeLogger<ChooseRepositoryViewModel>();
 
-        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+        using var viewModel = new ChooseRepositoryViewModel(mediator, logger, TimeSpan.FromMilliseconds(1));
 
         viewModel.Repository.ShouldBeNull();
         viewModel.LocalDirectoryPath.ShouldBe(string.Empty);
@@ -39,7 +41,8 @@ public class ChooseRepositoryViewModelTests
     public void SettingRepository_PopulatesViewModelFields()
     {
         var mediator = Substitute.For<IMediator>();
-        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+        var logger = new FakeLogger<ChooseRepositoryViewModel>();
+        using var viewModel = new ChooseRepositoryViewModel(mediator, logger, TimeSpan.FromMilliseconds(1));
 
         var repository = new RepositoryOptions
         {
@@ -63,12 +66,13 @@ public class ChooseRepositoryViewModelTests
     public async Task AccountCredentials_WhenQuerySucceeds_LoadsContainerNamesAndSelectsFirst()
     {
         var mediator = Substitute.For<IMediator>();
+        var logger = new FakeLogger<ChooseRepositoryViewModel>();
 
         mediator
             .CreateStream<string>(Arg.Is<ContainerNamesQuery>(q => q.AccountName == "account" && q.AccountKey == "key"), Arg.Any<CancellationToken>())
             .Returns(_ => new[] { "container-a", "container-b" }.ToAsyncEnumerable());
 
-        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+        using var viewModel = new ChooseRepositoryViewModel(mediator, logger, TimeSpan.FromMilliseconds(1));
 
         viewModel.AccountName = "account";
         viewModel.AccountKey = "key";
@@ -90,12 +94,13 @@ public class ChooseRepositoryViewModelTests
     public async Task AccountCredentials_WhenFactoryThrows_SetsErrorAndClearsContainers()
     {
         var mediator = Substitute.For<IMediator>();
+        var logger = new FakeLogger<ChooseRepositoryViewModel>();
 
         mediator
             .CreateStream<string>(Arg.Is<ContainerNamesQuery>(q => q.AccountName == "account" && q.AccountKey == "key"), Arg.Any<CancellationToken>())
             .Returns(_ => throw new InvalidOperationException("boom"));
 
-        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+        using var viewModel = new ChooseRepositoryViewModel(mediator, logger, TimeSpan.FromMilliseconds(1));
 
         viewModel.AccountName = "account";
         viewModel.AccountKey = "key";
@@ -116,7 +121,8 @@ public class ChooseRepositoryViewModelTests
     public void OpenRepositoryCommand_WhenConfigurationIsInvalid_IsDisabled()
     {
         var mediator = Substitute.For<IMediator>();
-        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+        var logger = new FakeLogger<ChooseRepositoryViewModel>();
+        using var viewModel = new ChooseRepositoryViewModel(mediator, logger, TimeSpan.FromMilliseconds(1));
 
         viewModel.LocalDirectoryPath = "C:/data";
         viewModel.AccountName = "account";
@@ -131,12 +137,13 @@ public class ChooseRepositoryViewModelTests
     public void OpenRepositoryCommand_WhenAllFieldsAreValid_IsEnabledAndBuildsRepository()
     {
         var mediator = Substitute.For<IMediator>();
+        var logger = new FakeLogger<ChooseRepositoryViewModel>();
 
         mediator
             .CreateStream<string>(Arg.Is<ContainerNamesQuery>(q => q.AccountName == "account" && q.AccountKey == "secret-key"), Arg.Any<CancellationToken>())
             .Returns(_ => new[] { "valid-container-123" }.ToAsyncEnumerable());
 
-        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+        using var viewModel = new ChooseRepositoryViewModel(mediator, logger, TimeSpan.FromMilliseconds(1));
 
         viewModel.LocalDirectoryPath = "C:/data";
         viewModel.AccountName = "account";
@@ -163,7 +170,8 @@ public class ChooseRepositoryViewModelTests
     public void OpenRepositoryCommand_WhenContainerNameViolatesAzureRules_IsDisabled()
     {
         var mediator = Substitute.For<IMediator>();
-        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+        var logger = new FakeLogger<ChooseRepositoryViewModel>();
+        using var viewModel = new ChooseRepositoryViewModel(mediator, logger, TimeSpan.FromMilliseconds(1));
 
         viewModel.LocalDirectoryPath = "C:/data";
         viewModel.AccountName = "account";
@@ -181,6 +189,7 @@ public class ChooseRepositoryViewModelTests
     public async Task AccountCredentials_WhenQueryReturnsNoContainers_ClearsContainerSelection()
     {
         var mediator = Substitute.For<IMediator>();
+        var logger = new FakeLogger<ChooseRepositoryViewModel>();
         var queryInvoked = false;
 
         mediator
@@ -191,7 +200,7 @@ public class ChooseRepositoryViewModelTests
                 return EmptyAsyncEnumerable();
             });
 
-        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+        using var viewModel = new ChooseRepositoryViewModel(mediator, logger, TimeSpan.FromMilliseconds(1));
 
         viewModel.ContainerName = "existing-container";
         viewModel.AccountName = "account";
@@ -211,6 +220,7 @@ public class ChooseRepositoryViewModelTests
     public async Task AccountCredentials_WhenCurrentContainerStillExists_PreservesSelection()
     {
         var mediator = Substitute.For<IMediator>();
+        var logger = new FakeLogger<ChooseRepositoryViewModel>();
         var queryInvoked = false;
 
         mediator
@@ -221,7 +231,7 @@ public class ChooseRepositoryViewModelTests
                 return new[] { "container-a", "container-b" }.ToAsyncEnumerable();
             });
 
-        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+        using var viewModel = new ChooseRepositoryViewModel(mediator, logger, TimeSpan.FromMilliseconds(1));
 
         viewModel.ContainerName = "container-b";
         viewModel.AccountName = "account";

--- a/src/Arius.Explorer.Tests/ChooseRepository/ChooseRepositoryViewModelTests.cs
+++ b/src/Arius.Explorer.Tests/ChooseRepository/ChooseRepositoryViewModelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -119,16 +120,20 @@ public class ChooseRepositoryViewModelTests
     [Test]
     public void OpenRepositoryCommand_WhenAllFieldsAreValid_IsEnabledAndBuildsRepository()
     {
-        Skip.Test("TODO");
-
         var mediator = Substitute.For<IMediator>();
+
+        mediator
+            .CreateStream<string>(Arg.Is<ContainerNamesQuery>(q => q.AccountName == "account" && q.AccountKey == "secret-key"), Arg.Any<CancellationToken>())
+            .Returns(_ => new[] { "valid-container-123" }.ToAsyncEnumerable());
+
         using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
 
         viewModel.LocalDirectoryPath = "C:/data";
         viewModel.AccountName = "account";
         viewModel.AccountKey = "secret-key";
-        viewModel.ContainerName = "valid-container-123";
         viewModel.Passphrase = "secret-pass";
+
+        WaitForAsync(() => viewModel.ContainerNames.Count == 1).GetAwaiter().GetResult();
 
         viewModel.OpenRepositoryCommand.CanExecute(null).ShouldBeTrue();
         viewModel.OpenRepositoryCommand.Execute(null);
@@ -139,6 +144,75 @@ public class ChooseRepositoryViewModelTests
         repository.ContainerName.ShouldBe("valid-container-123");
         repository.AccountKey.ShouldBe("secret-key");
         repository.Passphrase.ShouldBe("secret-pass");
+    }
+
+    [Test]
+    public void OpenRepositoryCommand_WhenContainerNameViolatesAzureRules_IsDisabled()
+    {
+        var mediator = Substitute.For<IMediator>();
+        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+
+        viewModel.LocalDirectoryPath = "C:/data";
+        viewModel.AccountName = "account";
+        viewModel.AccountKey = "key";
+        viewModel.Passphrase = "pass";
+
+        foreach (var invalidContainerName in new[] { "ab", "-abc", "abc-", "ab--cd", "Abc" })
+        {
+            viewModel.ContainerName = invalidContainerName;
+            viewModel.OpenRepositoryCommand.CanExecute(null).ShouldBeFalse($"{invalidContainerName} should be rejected");
+        }
+    }
+
+    [Test]
+    public async Task AccountCredentials_WhenQueryReturnsNoContainers_ClearsContainerSelection()
+    {
+        var mediator = Substitute.For<IMediator>();
+        var queryInvoked = false;
+
+        mediator
+            .CreateStream<string>(Arg.Is<ContainerNamesQuery>(q => q.AccountName == "account" && q.AccountKey == "key"), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                queryInvoked = true;
+                return EmptyAsyncEnumerable();
+            });
+
+        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+
+        viewModel.ContainerName = "existing-container";
+        viewModel.AccountName = "account";
+        viewModel.AccountKey = "key";
+
+        await WaitForAsync(() => queryInvoked && !viewModel.IsLoading);
+
+        viewModel.StorageAccountError.ShouldBeFalse();
+        viewModel.ContainerName.ShouldBe(string.Empty);
+    }
+
+    [Test]
+    public async Task AccountCredentials_WhenCurrentContainerStillExists_PreservesSelection()
+    {
+        var mediator = Substitute.For<IMediator>();
+        var queryInvoked = false;
+
+        mediator
+            .CreateStream<string>(Arg.Is<ContainerNamesQuery>(q => q.AccountName == "account" && q.AccountKey == "key"), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                queryInvoked = true;
+                return new[] { "container-a", "container-b" }.ToAsyncEnumerable();
+            });
+
+        using var viewModel = new ChooseRepositoryViewModel(mediator, TimeSpan.FromMilliseconds(1));
+
+        viewModel.ContainerName = "container-b";
+        viewModel.AccountName = "account";
+        viewModel.AccountKey = "key";
+
+        await WaitForAsync(() => queryInvoked && viewModel.ContainerNames.Count == 2);
+
+        viewModel.ContainerName.ShouldBe("container-b");
     }
 
     private static async Task WaitForAsync(Func<bool> condition, int timeoutMilliseconds = 1000)
@@ -155,5 +229,11 @@ public class ChooseRepositoryViewModelTests
 
             await Task.Delay(25);
         }
+    }
+
+    private static async IAsyncEnumerable<string> EmptyAsyncEnumerable()
+    {
+        await Task.CompletedTask;
+        yield break;
     }
 }

--- a/src/Arius.Explorer.Tests/ChooseRepository/ChooseRepositoryViewModelTests.cs
+++ b/src/Arius.Explorer.Tests/ChooseRepository/ChooseRepositoryViewModelTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
+using System.ComponentModel;
+using System.Threading.Channels;
 using System.Threading;
 using System.Threading.Tasks;
 using Arius.Core.Features.ContainerNamesQuery;
@@ -70,7 +73,10 @@ public class ChooseRepositoryViewModelTests
         viewModel.AccountName = "account";
         viewModel.AccountKey = "key";
 
-        await WaitForAsync(() => viewModel.ContainerNames.Count == 2);
+        await WaitForAsync(viewModel, () =>
+            viewModel.ContainerNames.Count == 2 &&
+            viewModel.ContainerName == "container-a" &&
+            !viewModel.IsLoading);
 
         viewModel.StorageAccountError.ShouldBeFalse();
         viewModel.IsLoading.ShouldBeFalse();
@@ -94,7 +100,11 @@ public class ChooseRepositoryViewModelTests
         viewModel.AccountName = "account";
         viewModel.AccountKey = "key";
 
-        await WaitForAsync(() => viewModel.StorageAccountError);
+        await WaitForAsync(viewModel, () =>
+            viewModel.StorageAccountError &&
+            !viewModel.IsLoading &&
+            viewModel.ContainerNames.Count == 0 &&
+            viewModel.ContainerName == string.Empty);
 
         viewModel.IsLoading.ShouldBeFalse();
         viewModel.StorageAccountError.ShouldBeTrue();
@@ -133,7 +143,10 @@ public class ChooseRepositoryViewModelTests
         viewModel.AccountKey = "secret-key";
         viewModel.Passphrase = "secret-pass";
 
-        WaitForAsync(() => viewModel.ContainerNames.Count == 1).GetAwaiter().GetResult();
+        WaitForAsync(viewModel, () =>
+            viewModel.ContainerNames.Count == 1 &&
+            viewModel.ContainerName == "valid-container-123" &&
+            !viewModel.IsLoading).GetAwaiter().GetResult();
 
         viewModel.OpenRepositoryCommand.CanExecute(null).ShouldBeTrue();
         viewModel.OpenRepositoryCommand.Execute(null);
@@ -184,7 +197,11 @@ public class ChooseRepositoryViewModelTests
         viewModel.AccountName = "account";
         viewModel.AccountKey = "key";
 
-        await WaitForAsync(() => queryInvoked && !viewModel.IsLoading);
+        await WaitForAsync(viewModel, () =>
+            queryInvoked &&
+            !viewModel.IsLoading &&
+            viewModel.ContainerNames.Count == 0 &&
+            viewModel.ContainerName == string.Empty);
 
         viewModel.StorageAccountError.ShouldBeFalse();
         viewModel.ContainerName.ShouldBe(string.Empty);
@@ -210,24 +227,61 @@ public class ChooseRepositoryViewModelTests
         viewModel.AccountName = "account";
         viewModel.AccountKey = "key";
 
-        await WaitForAsync(() => queryInvoked && viewModel.ContainerNames.Count == 2);
+        await WaitForAsync(viewModel, () =>
+            queryInvoked &&
+            viewModel.ContainerNames.Count == 2 &&
+            viewModel.ContainerName == "container-b" &&
+            !viewModel.IsLoading);
 
         viewModel.ContainerName.ShouldBe("container-b");
     }
 
-    private static async Task WaitForAsync(Func<bool> condition, int timeoutMilliseconds = 1000)
+    private static void Signal(Channel<bool> signal)
     {
-        var timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
-        var start = DateTime.UtcNow;
+        signal.Writer.TryWrite(true);
+    }
 
-        while (!condition())
+    private static async Task WaitForAsync(ChooseRepositoryViewModel viewModel, Func<bool> condition, int timeoutMilliseconds = 1000)
+    {
+        if (condition())
         {
-            if (DateTime.UtcNow - start > timeout)
-            {
-                throw new TimeoutException("Condition was not met within the allotted time.");
-            }
+            return;
+        }
 
-            await Task.Delay(25);
+        var signal = Channel.CreateBounded<bool>(new BoundedChannelOptions(1)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.DropOldest,
+        });
+
+        void OnPropertyChanged(object? _, PropertyChangedEventArgs __) => Signal(signal);
+        void OnContainerNamesChanged(object? _, NotifyCollectionChangedEventArgs __) => Signal(signal);
+
+        viewModel.PropertyChanged += OnPropertyChanged;
+        viewModel.ContainerNames.CollectionChanged += OnContainerNamesChanged;
+
+        try
+        {
+            Signal(signal);
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMilliseconds));
+
+            while (!condition())
+            {
+                await signal.Reader.WaitToReadAsync(cancellationTokenSource.Token);
+                while (signal.Reader.TryRead(out _))
+                {
+                    if (condition())
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            viewModel.PropertyChanged -= OnPropertyChanged;
+            viewModel.ContainerNames.CollectionChanged -= OnContainerNamesChanged;
         }
     }
 

--- a/src/Arius.Explorer.Tests/Infrastructure/RepositorySessionTests.cs
+++ b/src/Arius.Explorer.Tests/Infrastructure/RepositorySessionTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Arius.Core.Shared.Storage;
+using Arius.Explorer.Infrastructure;
+using Arius.Explorer.Settings;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Arius.Explorer.Tests.Infrastructure;
+
+public class RepositorySessionTests
+{
+    [Test]
+    public async Task ConnectAsync_WhenCalled_InitializesMediatorAndRepository()
+    {
+        var blobServiceFactory = Substitute.For<IBlobServiceFactory>();
+        var blobService = Substitute.For<IBlobService>();
+        var blobContainerService = Substitute.For<IBlobContainerService>();
+
+        blobServiceFactory.CreateAsync("account", "key", Arg.Any<CancellationToken>()).Returns(blobService);
+        blobService.GetContainerServiceAsync("container", PreflightMode.ReadOnly, Arg.Any<CancellationToken>()).Returns(blobContainerService);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(blobServiceFactory);
+        services.AddLogging();
+
+        await using var provider = services.BuildServiceProvider();
+        using var session = new RepositorySession(provider);
+
+        var repository = new RepositoryOptions
+        {
+            LocalDirectoryPath = "C:/data",
+            AccountName = "account",
+            AccountKeyProtected = "key",
+            ContainerName = "container",
+            PassphraseProtected = "pass",
+        };
+
+        await session.ConnectAsync(repository);
+
+        session.Repository.ShouldBe(repository);
+        session.Mediator.ShouldNotBeNull();
+        await blobServiceFactory.Received(1).CreateAsync("account", "key", Arg.Any<CancellationToken>());
+        await blobService.Received(1).GetContainerServiceAsync("container", PreflightMode.ReadOnly, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Dispose_WhenConnected_ClearsMediatorAndRepository()
+    {
+        var blobServiceFactory = Substitute.For<IBlobServiceFactory>();
+        var blobService = Substitute.For<IBlobService>();
+        var blobContainerService = Substitute.For<IBlobContainerService>();
+
+        blobServiceFactory.CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(blobService);
+        blobService.GetContainerServiceAsync(Arg.Any<string>(), Arg.Any<PreflightMode>(), Arg.Any<CancellationToken>()).Returns(blobContainerService);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(blobServiceFactory);
+        services.AddLogging();
+
+        await using var provider = services.BuildServiceProvider();
+        using var session = new RepositorySession(provider);
+
+        await session.ConnectAsync(new RepositoryOptions
+        {
+            LocalDirectoryPath = "C:/data",
+            AccountName = "account",
+            AccountKeyProtected = "key",
+            ContainerName = "container",
+            PassphraseProtected = "pass",
+        });
+
+        session.Dispose();
+
+        session.Repository.ShouldBeNull();
+        session.Mediator.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task AddRootCorePlaceholders_RegistersBlobContainerPlaceholderThatReportsNoBlobs()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        RepositorySession.AddRootCorePlaceholders(services);
+
+        await using var provider = services.BuildServiceProvider();
+        var blobContainerService = provider.GetRequiredService<IBlobContainerService>();
+
+        var metadata = await blobContainerService.GetMetadataAsync("missing");
+        var blobs = new List<string>();
+        await foreach (var blob in blobContainerService.ListAsync("chunks/"))
+        {
+            blobs.Add(blob);
+        }
+
+        metadata.Exists.ShouldBeFalse();
+        blobs.ShouldBeEmpty();
+        await blobContainerService.CreateContainerIfNotExistsAsync();
+        await Should.ThrowAsync<NotSupportedException>(() => blobContainerService.DownloadAsync("blob"));
+        await Should.ThrowAsync<NotSupportedException>(() => blobContainerService.OpenWriteAsync("blob"));
+        await Should.ThrowAsync<NotSupportedException>(() => blobContainerService.UploadAsync("blob", Stream.Null, new Dictionary<string, string>(), BlobTier.Cool));
+    }
+}

--- a/src/Arius.Explorer.Tests/RepositoryExplorer/FileItemViewModelTests.cs
+++ b/src/Arius.Explorer.Tests/RepositoryExplorer/FileItemViewModelTests.cs
@@ -1,0 +1,66 @@
+using System.Windows.Media;
+using Arius.Core.Features.ListQuery;
+using Arius.Core.Shared.ChunkStorage;
+using Arius.Explorer.RepositoryExplorer;
+
+namespace Arius.Explorer.Tests.RepositoryExplorer;
+
+public class FileItemViewModelTests
+{
+    [Test]
+    public void Constructor_MapsRepositoryFileStateToPresentationProperties()
+    {
+        var file = new RepositoryFileEntry(
+            RelativePath: "folder/file.txt",
+            ContentHash: "hash",
+            OriginalSize: 123,
+            Created: null,
+            Modified: null,
+            ExistsInCloud: true,
+            ExistsLocally: true,
+            HasPointerFile: true,
+            BinaryExists: true,
+            Hydrated: false);
+
+        var viewModel = new FileItemViewModel(file);
+
+        viewModel.Name.ShouldBe("file.txt");
+        viewModel.PointerFileStateColor.ShouldBe(Brushes.Black);
+        viewModel.BinaryFileStateColor.ShouldBe(Brushes.Blue);
+        viewModel.PointerFileEntryStateColor.ShouldBe(Brushes.Black);
+        viewModel.OriginalLength.ShouldBe(123);
+        viewModel.HydrationStatus.ShouldBe(ChunkHydrationStatus.NeedsRehydration);
+        viewModel.ChunkStateColor.ShouldBe(Brushes.LightBlue);
+        viewModel.StateTooltip.ShouldContain("rehydrated");
+    }
+
+    [Test]
+    public void HydrationStatus_WhenChanged_UpdatesChunkStateColorAndTooltip()
+    {
+        var file = new RepositoryFileEntry(
+            RelativePath: "file.txt",
+            ContentHash: "hash",
+            OriginalSize: 1,
+            Created: null,
+            Modified: null,
+            ExistsInCloud: true,
+            ExistsLocally: true,
+            HasPointerFile: false,
+            BinaryExists: false,
+            Hydrated: null);
+
+        var viewModel = new FileItemViewModel(file);
+
+        viewModel.HydrationStatus = ChunkHydrationStatus.Available;
+        viewModel.ChunkStateColor.ShouldBe(Brushes.Blue);
+        viewModel.StateTooltip.ShouldBe("Cloud chunk is available for download");
+
+        viewModel.HydrationStatus = ChunkHydrationStatus.RehydrationPending;
+        viewModel.ChunkStateColor.ShouldBe(Brushes.Purple);
+        viewModel.StateTooltip.ShouldBe("Cloud chunk rehydration is already pending");
+
+        viewModel.HydrationStatus = ChunkHydrationStatus.Unknown;
+        viewModel.ChunkStateColor.ShouldBe(Brushes.Transparent);
+        viewModel.StateTooltip.ShouldBe("Cloud chunk status not loaded yet");
+    }
+}

--- a/src/Arius.Explorer.Tests/RepositoryExplorer/RepositoryExplorerViewModelTests.cs
+++ b/src/Arius.Explorer.Tests/RepositoryExplorer/RepositoryExplorerViewModelTests.cs
@@ -25,10 +25,19 @@ namespace Arius.Explorer.Tests.RepositoryExplorer;
 [NotInParallel("RepositoryExplorerViewModelTests")]
 public class RepositoryExplorerViewModelTests
 {
+    private Func<string, string, MessageBoxButton, MessageBoxImage, MessageBoxResult> originalShowMessageBox = null!;
+
     [Before(Test)]
     public void ResetMessageBox()
     {
+        originalShowMessageBox = RepositoryExplorerViewModel.ShowMessageBox;
         RepositoryExplorerViewModel.ShowMessageBox = static (_, _, _, _) => MessageBoxResult.OK;
+    }
+
+    [After(Test)]
+    public void RestoreMessageBox()
+    {
+        RepositoryExplorerViewModel.ShowMessageBox = originalShowMessageBox;
     }
 
     [Test]
@@ -145,6 +154,8 @@ public class RepositoryExplorerViewModelTests
         await WaitForAsync(viewModel, () => viewModel.RootNode.Count == 1 && viewModel.Repository != null);
 
         viewModel.Repository.ShouldBe(repository);
+        repositorySession.ConnectCalls.ShouldBe(1);
+        repositorySession.Repository.ShouldBe(repository);
         recentRepositoryManager.Received(1).TouchOrAdd(repository);
         dialogService.Received(1).ShowChooseRepositoryDialog(null);
     }

--- a/src/Arius.Explorer.Tests/RepositoryExplorer/RepositoryExplorerViewModelTests.cs
+++ b/src/Arius.Explorer.Tests/RepositoryExplorer/RepositoryExplorerViewModelTests.cs
@@ -1,0 +1,375 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Arius.Core.Features.ChunkHydrationStatusQuery;
+using Arius.Core.Features.ListQuery;
+using Arius.Core.Features.RestoreCommand;
+using Arius.Core.Shared.ChunkStorage;
+using Arius.Explorer.Infrastructure;
+using Arius.Explorer.RepositoryExplorer;
+using Arius.Explorer.Settings;
+using Arius.Explorer.Shared.Services;
+using Mediator;
+using Microsoft.Extensions.Logging.Testing;
+using NSubstitute;
+
+namespace Arius.Explorer.Tests.RepositoryExplorer;
+
+[NotInParallel("RepositoryExplorerViewModelTests")]
+public class RepositoryExplorerViewModelTests
+{
+    [Before(Test)]
+    public void ResetMessageBox()
+    {
+        RepositoryExplorerViewModel.ShowMessageBox = static (_, _, _, _) => MessageBoxResult.OK;
+    }
+
+    [Test]
+    public void Constructor_WhenNoRecentRepository_StartsEmpty()
+    {
+        var settings = new FakeApplicationSettings();
+        var recentRepositoryManager = Substitute.For<IRecentRepositoryManager>();
+        var dialogService = Substitute.For<IDialogService>();
+        using var repositorySession = new FakeRepositorySession();
+        var logger = new FakeLogger<RepositoryExplorerViewModel>();
+
+        var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger);
+
+        viewModel.RecentRepositories.ShouldBe(settings.RecentRepositories);
+        viewModel.Repository.ShouldBeNull();
+        viewModel.SelectedItemsText.ShouldBe("0 item(s)");
+    }
+
+    [Test]
+    public async Task Constructor_WhenRecentRepositoryExists_LoadsRepositoryTree()
+    {
+        var repository = CreateRepository();
+        var settings = new FakeApplicationSettings();
+        settings.RecentRepositories.Add(repository);
+        var recentRepositoryManager = Substitute.For<IRecentRepositoryManager>();
+        recentRepositoryManager.GetMostRecent().Returns(repository);
+
+        var mediator = Substitute.For<IMediator>();
+        mediator.CreateStream(Arg.Any<ListQuery>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ToAsyncEnumerable<RepositoryEntry>(
+                new RepositoryDirectoryEntry("/folder1/folder2/", null, true, true),
+                new RepositoryFileEntry("/folder1/file-a.txt", "hash-a", 1024, null, null, true, true, true, true, null),
+                new RepositoryFileEntry("/folder1/file-b.txt", null, 2048, null, null, false, true, false, true, null)));
+        mediator.CreateStream(Arg.Any<ChunkHydrationStatusQuery>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ToAsyncEnumerable(
+                new ChunkHydrationStatusResult("/folder1/file-a.txt", "hash-a", ChunkHydrationStatus.Available)));
+
+        var dialogService = Substitute.For<IDialogService>();
+        using var repositorySession = new FakeRepositorySession { Mediator = mediator };
+        var logger = new FakeLogger<RepositoryExplorerViewModel>();
+
+        var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger);
+
+        await WaitForAsync(() =>
+            viewModel.RootNode.Count == 1 &&
+            viewModel.SelectedTreeNode?.Items.Count == 2 &&
+            viewModel.SelectedTreeNode.Items[0].HydrationStatus == ChunkHydrationStatus.Available);
+
+        repositorySession.ConnectCalls.ShouldBe(1);
+        viewModel.Repository.ShouldBe(repository);
+        viewModel.RootNode.Count.ShouldBe(1);
+        viewModel.SelectedTreeNode.ShouldNotBeNull();
+        viewModel.SelectedTreeNode.Name.ShouldBe("Root");
+        viewModel.SelectedTreeNode.Folders.Count.ShouldBe(1);
+        viewModel.SelectedTreeNode.Folders[0].Name.ShouldBe("folder2");
+        viewModel.SelectedTreeNode.Items[0].HydrationStatus.ShouldBe(ChunkHydrationStatus.Available);
+        viewModel.SelectedItemsText.ShouldContain("2 item(s)");
+    }
+
+    [Test]
+    public async Task ViewLoadedCommand_WhenRepositoryMissing_OpensDialog()
+    {
+        var settings = new FakeApplicationSettings();
+        var recentRepositoryManager = Substitute.For<IRecentRepositoryManager>();
+        var dialogService = Substitute.For<IDialogService>();
+        using var repositorySession = new FakeRepositorySession();
+        var logger = new FakeLogger<RepositoryExplorerViewModel>();
+
+        var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger);
+
+        await viewModel.ViewLoadedCommand.ExecuteAsync(null);
+
+        dialogService.Received(1).ShowChooseRepositoryDialog(null);
+    }
+
+    [Test]
+    public async Task ViewLoadedCommand_WhenRepositoryAlreadySet_DoesNotOpenDialog()
+    {
+        var settings = new FakeApplicationSettings();
+        var recentRepositoryManager = Substitute.For<IRecentRepositoryManager>();
+        var dialogService = Substitute.For<IDialogService>();
+        using var repositorySession = new FakeRepositorySession();
+        var logger = new FakeLogger<RepositoryExplorerViewModel>();
+
+        var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger)
+        {
+            Repository = CreateRepository()
+        };
+
+        await viewModel.ViewLoadedCommand.ExecuteAsync(null);
+
+        dialogService.DidNotReceive().ShowChooseRepositoryDialog(Arg.Any<RepositoryOptions>());
+    }
+
+    [Test]
+    public async Task OpenChooseRepositoryDialogCommand_WhenRepositorySelected_LoadsRepositoryAndTracksRecent()
+    {
+        var repository = CreateRepository();
+        var settings = new FakeApplicationSettings();
+        var recentRepositoryManager = Substitute.For<IRecentRepositoryManager>();
+        var dialogService = Substitute.For<IDialogService>();
+        dialogService.ShowChooseRepositoryDialog(null).Returns(repository);
+
+        var mediator = Substitute.For<IMediator>();
+        mediator.CreateStream(Arg.Any<ListQuery>(), Arg.Any<CancellationToken>()).Returns(_ => EmptyAsyncEnumerable<RepositoryEntry>());
+        mediator.CreateStream(Arg.Any<ChunkHydrationStatusQuery>(), Arg.Any<CancellationToken>()).Returns(_ => EmptyAsyncEnumerable<ChunkHydrationStatusResult>());
+
+        using var repositorySession = new FakeRepositorySession { Mediator = mediator };
+        var logger = new FakeLogger<RepositoryExplorerViewModel>();
+
+        var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger);
+
+        await viewModel.OpenChooseRepositoryDialogCommand.ExecuteAsync(null);
+        await WaitForAsync(() => viewModel.RootNode.Count == 1 && viewModel.Repository != null);
+
+        viewModel.Repository.ShouldBe(repository);
+        recentRepositoryManager.Received(1).TouchOrAdd(repository);
+        dialogService.Received(1).ShowChooseRepositoryDialog(null);
+    }
+
+    [Test]
+    public void ItemSelectionChangedCommand_UpdatesSelectedFilesAndSummary()
+    {
+        var settings = new FakeApplicationSettings();
+        var recentRepositoryManager = Substitute.For<IRecentRepositoryManager>();
+        var dialogService = Substitute.For<IDialogService>();
+        using var repositorySession = new FakeRepositorySession();
+        var logger = new FakeLogger<RepositoryExplorerViewModel>();
+
+        var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger);
+        var fileA = new FileItemViewModel(new RepositoryFileEntry("/file-a.txt", "hash-a", 1024, null, null, true, true, true, true, true));
+        var fileB = new FileItemViewModel(new RepositoryFileEntry("/file-b.txt", "hash-b", 2048, null, null, true, true, true, true, true));
+        var selectedTreeNode = new TreeNodeViewModel("/", showPlaceholder: false)
+        {
+            Items = new ObservableCollection<FileItemViewModel> { fileA, fileB }
+        };
+
+        viewModel.SelectedTreeNode = selectedTreeNode;
+
+        fileA.IsSelected = true;
+        viewModel.ItemSelectionChangedCommand.Execute(fileA);
+
+        viewModel.SelectedFiles.ShouldContain(fileA);
+        viewModel.SelectedItemsText.ShouldContain("1 of 2 item(s) selected");
+
+        fileA.IsSelected = false;
+        viewModel.ItemSelectionChangedCommand.Execute(fileA);
+
+        viewModel.SelectedFiles.ShouldNotContain(fileA);
+        viewModel.SelectedItemsText.ShouldContain("2 item(s)");
+    }
+
+    [Test]
+    public async Task RestoreCommand_WhenNothingIsSelected_ReturnsWithoutCallingMediator()
+    {
+        var settings = new FakeApplicationSettings();
+        var recentRepositoryManager = Substitute.For<IRecentRepositoryManager>();
+        var dialogService = Substitute.For<IDialogService>();
+        var mediator = Substitute.For<IMediator>();
+        using var repositorySession = new FakeRepositorySession { Mediator = mediator };
+        var logger = new FakeLogger<RepositoryExplorerViewModel>();
+
+        var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger)
+        {
+            Repository = CreateRepository()
+        };
+
+        await viewModel.RestoreCommand.ExecuteAsync(null);
+
+        await mediator.DidNotReceiveWithAnyArgs().Send(default!);
+    }
+
+    [Test]
+    public async Task RestoreCommand_WhenUserDeclinesConfirmation_DoesNotSendRestoreCommands()
+    {
+        var settings = new FakeApplicationSettings();
+        var recentRepositoryManager = Substitute.For<IRecentRepositoryManager>();
+        var dialogService = Substitute.For<IDialogService>();
+        var mediator = Substitute.For<IMediator>();
+        mediator.CreateStream(Arg.Any<ChunkHydrationStatusQuery>(), Arg.Any<CancellationToken>())
+            .Returns(_ => EmptyAsyncEnumerable<ChunkHydrationStatusResult>());
+
+        using var repositorySession = new FakeRepositorySession { Mediator = mediator };
+        var logger = new FakeLogger<RepositoryExplorerViewModel>();
+        var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger)
+        {
+            Repository = CreateRepository(),
+            SelectedTreeNode = new TreeNodeViewModel("/", showPlaceholder: false)
+        };
+
+        viewModel.SelectedFiles.Add(new FileItemViewModel(new RepositoryFileEntry("/file-a.txt", "hash-a", 1024, null, null, true, true, true, true, true)));
+        RepositoryExplorerViewModel.ShowMessageBox = static (_, _, _, _) => MessageBoxResult.No;
+
+        await viewModel.RestoreCommand.ExecuteAsync(null);
+
+        await mediator.DidNotReceiveWithAnyArgs().Send(default!);
+        viewModel.IsLoading.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task RestoreCommand_WhenUserConfirms_RestoresFilesAndRefreshesNode()
+    {
+        var settings = new FakeApplicationSettings();
+        var recentRepositoryManager = Substitute.For<IRecentRepositoryManager>();
+        var dialogService = Substitute.For<IDialogService>();
+        var mediator = Substitute.For<IMediator>();
+
+        mediator.CreateStream(Arg.Any<ListQuery>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ToAsyncEnumerable<RepositoryEntry>(
+                new RepositoryFileEntry("/file-a.txt", "hash-a", 1024, null, null, true, true, true, true, true)));
+        mediator.CreateStream(Arg.Any<ChunkHydrationStatusQuery>(), Arg.Any<CancellationToken>())
+            .Returns(_ => EmptyAsyncEnumerable<ChunkHydrationStatusResult>());
+        mediator.Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
+            .Returns(new RestoreResult { Success = true, FilesRestored = 1, FilesSkipped = 0, ChunksPendingRehydration = 0 });
+
+        using var repositorySession = new FakeRepositorySession { Mediator = mediator };
+        var logger = new FakeLogger<RepositoryExplorerViewModel>();
+        var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger)
+        {
+            Repository = CreateRepository()
+        };
+
+        var node = new TreeNodeViewModel("/", showPlaceholder: false)
+        {
+            Items = new ObservableCollection<FileItemViewModel>
+            {
+                new(new RepositoryFileEntry("/file-a.txt", "hash-a", 1024, null, null, true, true, true, true, true))
+            }
+        };
+
+        viewModel.SelectedTreeNode = node;
+        viewModel.SelectedFiles.Add(node.Items.Single());
+        RepositoryExplorerViewModel.ShowMessageBox = static (_, _, _, _) => MessageBoxResult.Yes;
+
+        await viewModel.RestoreCommand.ExecuteAsync(null);
+        await WaitForAsync(() => viewModel.SelectedTreeNode?.Items.Count == 1 && viewModel.SelectedFiles.Count == 0);
+
+        await mediator.Received(1).Send(
+            Arg.Is<RestoreCommand>(command =>
+                command.Options.RootDirectory == "C:/data" &&
+                command.Options.TargetPath == "/file-a.txt" &&
+                command.Options.Overwrite &&
+                command.Options.NoPointers == false),
+            Arg.Any<CancellationToken>());
+        viewModel.SelectedFiles.ShouldBeEmpty();
+        viewModel.IsLoading.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task RestoreCommand_WhenRestoreFails_ShowsErrorAndKeepsSelection()
+    {
+        var settings = new FakeApplicationSettings();
+        var recentRepositoryManager = Substitute.For<IRecentRepositoryManager>();
+        var dialogService = Substitute.For<IDialogService>();
+        var mediator = Substitute.For<IMediator>();
+
+        mediator.CreateStream(Arg.Any<ChunkHydrationStatusQuery>(), Arg.Any<CancellationToken>())
+            .Returns(_ => EmptyAsyncEnumerable<ChunkHydrationStatusResult>());
+        mediator.Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
+            .Returns(new RestoreResult { Success = false, FilesRestored = 0, FilesSkipped = 0, ChunksPendingRehydration = 0, ErrorMessage = "boom" });
+
+        using var repositorySession = new FakeRepositorySession { Mediator = mediator };
+        var logger = new FakeLogger<RepositoryExplorerViewModel>();
+        var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger)
+        {
+            Repository = CreateRepository(),
+            SelectedTreeNode = new TreeNodeViewModel("/", showPlaceholder: false)
+        };
+
+        var selectedFile = new FileItemViewModel(new RepositoryFileEntry("/file-a.txt", "hash-a", 1024, null, null, true, true, true, true, true));
+        viewModel.SelectedFiles.Add(selectedFile);
+
+        string shownMessage = string.Empty;
+        RepositoryExplorerViewModel.ShowMessageBox = (message, _, _, _) =>
+        {
+            shownMessage = message;
+            return MessageBoxResult.Yes;
+        };
+
+        await viewModel.RestoreCommand.ExecuteAsync(null);
+
+        shownMessage.ShouldContain("Restore failed: boom");
+        viewModel.SelectedFiles.ShouldContain(selectedFile);
+        viewModel.IsLoading.ShouldBeFalse();
+    }
+
+    private static RepositoryOptions CreateRepository()
+    {
+        return new RepositoryOptions
+        {
+            LocalDirectoryPath = "C:/data",
+            AccountName = "account",
+            AccountKeyProtected = "key",
+            ContainerName = "container",
+            PassphraseProtected = "pass",
+        };
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMilliseconds = 1000)
+    {
+        var timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
+        var start = DateTime.UtcNow;
+
+        while (!condition())
+        {
+            if (DateTime.UtcNow - start > timeout)
+            {
+                throw new TimeoutException("Condition was not met within the allotted time.");
+            }
+
+            await Task.Delay(25);
+        }
+    }
+
+    private sealed class FakeRepositorySession : IRepositorySession
+    {
+        public IMediator Mediator { get; set; }
+        public RepositoryOptions Repository { get; set; }
+        public int ConnectCalls { get; private set; }
+
+        public Task ConnectAsync(RepositoryOptions repository, CancellationToken cancellationToken = default)
+        {
+            ConnectCalls++;
+            Repository = repository;
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(params T[] items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+            await Task.Yield();
+        }
+    }
+
+    private static async IAsyncEnumerable<T> EmptyAsyncEnumerable<T>()
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+}

--- a/src/Arius.Explorer.Tests/RepositoryExplorer/RepositoryExplorerViewModelTests.cs
+++ b/src/Arius.Explorer.Tests/RepositoryExplorer/RepositoryExplorerViewModelTests.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
+using System.Threading.Channels;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -69,7 +72,7 @@ public class RepositoryExplorerViewModelTests
 
         var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger);
 
-        await WaitForAsync(() =>
+        await WaitForAsync(viewModel, () =>
             viewModel.RootNode.Count == 1 &&
             viewModel.SelectedTreeNode?.Items.Count == 2 &&
             viewModel.SelectedTreeNode.Items[0].HydrationStatus == ChunkHydrationStatus.Available);
@@ -139,7 +142,7 @@ public class RepositoryExplorerViewModelTests
         var viewModel = new RepositoryExplorerViewModel(settings, recentRepositoryManager, dialogService, repositorySession, logger);
 
         await viewModel.OpenChooseRepositoryDialogCommand.ExecuteAsync(null);
-        await WaitForAsync(() => viewModel.RootNode.Count == 1 && viewModel.Repository != null);
+        await WaitForAsync(viewModel, () => viewModel.RootNode.Count == 1 && viewModel.Repository != null);
 
         viewModel.Repository.ShouldBe(repository);
         recentRepositoryManager.Received(1).TouchOrAdd(repository);
@@ -261,7 +264,7 @@ public class RepositoryExplorerViewModelTests
         RepositoryExplorerViewModel.ShowMessageBox = static (_, _, _, _) => MessageBoxResult.Yes;
 
         await viewModel.RestoreCommand.ExecuteAsync(null);
-        await WaitForAsync(() => viewModel.SelectedTreeNode?.Items.Count == 1 && viewModel.SelectedFiles.Count == 0);
+        await WaitForAsync(viewModel, () => viewModel.SelectedTreeNode?.Items.Count == 1 && viewModel.SelectedFiles.Count == 0);
 
         await mediator.Received(1).Send(
             Arg.Is<RestoreCommand>(command =>
@@ -324,19 +327,82 @@ public class RepositoryExplorerViewModelTests
         };
     }
 
-    private static async Task WaitForAsync(Func<bool> condition, int timeoutMilliseconds = 1000)
+    private static async Task WaitForAsync(RepositoryExplorerViewModel viewModel, Func<bool> condition, int timeoutMilliseconds = 1000)
     {
-        var timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
-        var start = DateTime.UtcNow;
-
-        while (!condition())
+        if (condition())
         {
-            if (DateTime.UtcNow - start > timeout)
+            return;
+        }
+
+        var signal = Channel.CreateBounded<bool>(new BoundedChannelOptions(1)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.DropOldest,
+        });
+
+        void Notify() => signal.Writer.TryWrite(true);
+        void OnViewModelPropertyChanged(object? _, PropertyChangedEventArgs __) => Notify();
+        void OnRootNodeChanged(object? _, NotifyCollectionChangedEventArgs __) => Notify();
+        void OnSelectedFilesChanged(object? _, NotifyCollectionChangedEventArgs __) => Notify();
+        void OnSelectedTreeNodePropertyChanged(object? _, PropertyChangedEventArgs __) => Notify();
+        void OnSelectedTreeNodeItemsChanged(object? _, NotifyCollectionChangedEventArgs __) => Notify();
+
+        TreeNodeViewModel? subscribedTreeNode = null;
+
+        void AttachSelectedTreeNode(TreeNodeViewModel? node)
+        {
+            if (ReferenceEquals(subscribedTreeNode, node))
             {
-                throw new TimeoutException("Condition was not met within the allotted time.");
+                return;
             }
 
-            await Task.Delay(25);
+            if (subscribedTreeNode is not null)
+            {
+                subscribedTreeNode.PropertyChanged -= OnSelectedTreeNodePropertyChanged;
+                subscribedTreeNode.Items.CollectionChanged -= OnSelectedTreeNodeItemsChanged;
+            }
+
+            subscribedTreeNode = node;
+
+            if (subscribedTreeNode is not null)
+            {
+                subscribedTreeNode.PropertyChanged += OnSelectedTreeNodePropertyChanged;
+                subscribedTreeNode.Items.CollectionChanged += OnSelectedTreeNodeItemsChanged;
+            }
+        }
+
+        viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        viewModel.RootNode.CollectionChanged += OnRootNodeChanged;
+        viewModel.SelectedFiles.CollectionChanged += OnSelectedFilesChanged;
+        AttachSelectedTreeNode(viewModel.SelectedTreeNode);
+
+        try
+        {
+            Notify();
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMilliseconds));
+
+            while (!condition())
+            {
+                AttachSelectedTreeNode(viewModel.SelectedTreeNode);
+
+                await signal.Reader.WaitToReadAsync(cancellationTokenSource.Token);
+                while (signal.Reader.TryRead(out _))
+                {
+                    AttachSelectedTreeNode(viewModel.SelectedTreeNode);
+                    if (condition())
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            viewModel.RootNode.CollectionChanged -= OnRootNodeChanged;
+            viewModel.SelectedFiles.CollectionChanged -= OnSelectedFilesChanged;
+            AttachSelectedTreeNode(null);
         }
     }
 

--- a/src/Arius.Explorer.Tests/RepositoryExplorer/TreeNodeViewModelTests.cs
+++ b/src/Arius.Explorer.Tests/RepositoryExplorer/TreeNodeViewModelTests.cs
@@ -1,0 +1,38 @@
+using Arius.Explorer.RepositoryExplorer;
+
+namespace Arius.Explorer.Tests.RepositoryExplorer;
+
+public class TreeNodeViewModelTests
+{
+    [Test]
+    public void Constructor_WithPlaceholder_AddsLoadingChild()
+    {
+        var node = new TreeNodeViewModel("/root/");
+
+        node.Prefix.ShouldBe("/root/");
+        node.Folders.Count.ShouldBe(1);
+        node.Folders[0].Name.ShouldBe("Loading...");
+    }
+
+    [Test]
+    public void IsSelected_WhenSetToTrue_ExpandsAndInvokesCallback()
+    {
+        TreeNodeViewModel selectedNode = null!;
+        var node = new TreeNodeViewModel("/root/", onSelected: selected => selectedNode = selected, showPlaceholder: false);
+
+        node.IsSelected = true;
+
+        node.IsExpanded.ShouldBeTrue();
+        selectedNode.ShouldBe(node);
+    }
+
+    [Test]
+    public void IsExpanded_WhenSetToTrue_SelectsNode()
+    {
+        var node = new TreeNodeViewModel("/root/", showPlaceholder: false);
+
+        node.IsExpanded = true;
+
+        node.IsSelected.ShouldBeTrue();
+    }
+}

--- a/src/Arius.Explorer.Tests/Settings/ApplicationSettingsTests.cs
+++ b/src/Arius.Explorer.Tests/Settings/ApplicationSettingsTests.cs
@@ -14,4 +14,27 @@ public class ApplicationSettingsTests
         settings.UpgradeRequired.ShouldBeTrue();
     }
 
+    [Test]
+    public void RecentRepositories_WhenUnset_ReturnsReusableCollection()
+    {
+        var settings = new ApplicationSettings();
+
+        var first = settings.RecentRepositories;
+        var second = settings.RecentRepositories;
+
+        first.ShouldNotBeNull();
+        second.ShouldBeSameAs(first);
+    }
+
+    [Test]
+    public void UpgradeRequired_WhenSetFalse_ReturnsFalse()
+    {
+        var settings = new ApplicationSettings
+        {
+            UpgradeRequired = false,
+        };
+
+        settings.UpgradeRequired.ShouldBeFalse();
+    }
+
 }

--- a/src/Arius.Explorer.Tests/Settings/RecentRepositoryManagerTests.cs
+++ b/src/Arius.Explorer.Tests/Settings/RecentRepositoryManagerTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using System.Linq;
 using Arius.Explorer.Settings;
 
 namespace Arius.Explorer.Tests.Settings;
@@ -78,5 +79,43 @@ public class RecentRepositoryManagerTests
         settings.RecentRepositories.Count.ShouldBe(1);
         settings.RecentRepositories[0].ContainerName.ShouldBe("keep");
         settings.SaveCalls.ShouldBe(1);
+    }
+
+    [Test]
+    public void RecentRepositoryManager_TouchOrAdd_RespectsRecentLimit()
+    {
+        var settings = new FakeApplicationSettings { RecentLimit = 2 };
+        var manager = new RecentRepositoryManager(settings);
+
+        manager.TouchOrAdd(new RepositoryOptions { LocalDirectoryPath = "C:/a", AccountName = "acct", ContainerName = "repo-a" });
+        Task.Delay(5).GetAwaiter().GetResult();
+        manager.TouchOrAdd(new RepositoryOptions { LocalDirectoryPath = "C:/b", AccountName = "acct", ContainerName = "repo-b" });
+        Task.Delay(5).GetAwaiter().GetResult();
+        manager.TouchOrAdd(new RepositoryOptions { LocalDirectoryPath = "C:/c", AccountName = "acct", ContainerName = "repo-c" });
+
+        manager.GetAll().Select(repo => repo.ContainerName).ShouldBe(["repo-c", "repo-b"]);
+    }
+
+    [Test]
+    public void RecentRepositoryManager_GetMostRecent_WhenEmpty_ReturnsNull()
+    {
+        var settings = new FakeApplicationSettings();
+        var manager = new RecentRepositoryManager(settings);
+
+        manager.GetMostRecent().ShouldBeNull();
+    }
+
+    [Test]
+    public void RecentRepositoryManager_Remove_WhenNothingMatches_DoesNotSave()
+    {
+        var settings = new FakeApplicationSettings();
+        var manager = new RecentRepositoryManager(settings);
+
+        settings.RecentRepositories.Add(new RepositoryOptions { LocalDirectoryPath = "C:/a", AccountName = "acct", ContainerName = "keep" });
+
+        manager.Remove(repo => repo.ContainerName == "missing");
+
+        settings.RecentRepositories.Count.ShouldBe(1);
+        settings.SaveCalls.ShouldBe(0);
     }
 }

--- a/src/Arius.Explorer.Tests/Settings/RecentRepositoryManagerTests.cs
+++ b/src/Arius.Explorer.Tests/Settings/RecentRepositoryManagerTests.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+using System;
 using System.Linq;
 using Arius.Explorer.Settings;
 
@@ -10,7 +10,8 @@ public class RecentRepositoryManagerTests
     public void RecentRepositoryManager_TouchOrAdd_AddsAndOrdersMostRecentFirst()
     {
         var settings = new FakeApplicationSettings();
-        var manager = new RecentRepositoryManager(settings);
+        var times = CreateClock(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 1, 1, 0, 0, 1, DateTimeKind.Utc));
+        var manager = new RecentRepositoryManager(settings, times);
 
         var repoA = new RepositoryOptions
         {
@@ -26,7 +27,6 @@ public class RecentRepositoryManagerTests
         };
 
         manager.TouchOrAdd(repoA);
-        Task.Delay(5).GetAwaiter().GetResult();
         manager.TouchOrAdd(repoB);
 
         manager.GetAll().Count.ShouldBe(2);
@@ -38,7 +38,8 @@ public class RecentRepositoryManagerTests
     public void RecentRepositoryManager_TouchOrAdd_UpdatesExistingWithoutDuplicating()
     {
         var settings = new FakeApplicationSettings();
-        var manager = new RecentRepositoryManager(settings);
+        var times = CreateClock(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 1, 1, 0, 0, 1, DateTimeKind.Utc));
+        var manager = new RecentRepositoryManager(settings, times);
 
         var original = new RepositoryOptions
         {
@@ -85,12 +86,13 @@ public class RecentRepositoryManagerTests
     public void RecentRepositoryManager_TouchOrAdd_RespectsRecentLimit()
     {
         var settings = new FakeApplicationSettings { RecentLimit = 2 };
-        var manager = new RecentRepositoryManager(settings);
+        var manager = new RecentRepositoryManager(settings, CreateClock(
+            new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 1, 1, 0, 0, 1, DateTimeKind.Utc),
+            new DateTime(2026, 1, 1, 0, 0, 2, DateTimeKind.Utc)));
 
         manager.TouchOrAdd(new RepositoryOptions { LocalDirectoryPath = "C:/a", AccountName = "acct", ContainerName = "repo-a" });
-        Task.Delay(5).GetAwaiter().GetResult();
         manager.TouchOrAdd(new RepositoryOptions { LocalDirectoryPath = "C:/b", AccountName = "acct", ContainerName = "repo-b" });
-        Task.Delay(5).GetAwaiter().GetResult();
         manager.TouchOrAdd(new RepositoryOptions { LocalDirectoryPath = "C:/c", AccountName = "acct", ContainerName = "repo-c" });
 
         manager.GetAll().Select(repo => repo.ContainerName).ShouldBe(["repo-c", "repo-b"]);
@@ -117,5 +119,11 @@ public class RecentRepositoryManagerTests
 
         settings.RecentRepositories.Count.ShouldBe(1);
         settings.SaveCalls.ShouldBe(0);
+    }
+
+    private static Func<DateTime> CreateClock(params DateTime[] values)
+    {
+        var index = 0;
+        return () => values[Math.Min(index++, values.Length - 1)];
     }
 }

--- a/src/Arius.Explorer.Tests/Settings/RecentRepositoryManagerTests.cs
+++ b/src/Arius.Explorer.Tests/Settings/RecentRepositoryManagerTests.cs
@@ -10,8 +10,10 @@ public class RecentRepositoryManagerTests
     public void RecentRepositoryManager_TouchOrAdd_AddsAndOrdersMostRecentFirst()
     {
         var settings = new FakeApplicationSettings();
-        var times = CreateClock(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 1, 1, 0, 0, 1, DateTimeKind.Utc));
-        var manager = new RecentRepositoryManager(settings, times);
+        var timeProvider = new SequencedTimeProvider(
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 1, 1, 0, 0, 1, TimeSpan.Zero));
+        var manager = new RecentRepositoryManager(settings, timeProvider);
 
         var repoA = new RepositoryOptions
         {
@@ -38,8 +40,10 @@ public class RecentRepositoryManagerTests
     public void RecentRepositoryManager_TouchOrAdd_UpdatesExistingWithoutDuplicating()
     {
         var settings = new FakeApplicationSettings();
-        var times = CreateClock(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 1, 1, 0, 0, 1, DateTimeKind.Utc));
-        var manager = new RecentRepositoryManager(settings, times);
+        var timeProvider = new SequencedTimeProvider(
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 1, 1, 0, 0, 1, TimeSpan.Zero));
+        var manager = new RecentRepositoryManager(settings, timeProvider);
 
         var original = new RepositoryOptions
         {
@@ -86,10 +90,10 @@ public class RecentRepositoryManagerTests
     public void RecentRepositoryManager_TouchOrAdd_RespectsRecentLimit()
     {
         var settings = new FakeApplicationSettings { RecentLimit = 2 };
-        var manager = new RecentRepositoryManager(settings, CreateClock(
-            new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            new DateTime(2026, 1, 1, 0, 0, 1, DateTimeKind.Utc),
-            new DateTime(2026, 1, 1, 0, 0, 2, DateTimeKind.Utc)));
+        var manager = new RecentRepositoryManager(settings, new SequencedTimeProvider(
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 1, 1, 0, 0, 1, TimeSpan.Zero),
+            new DateTimeOffset(2026, 1, 1, 0, 0, 2, TimeSpan.Zero)));
 
         manager.TouchOrAdd(new RepositoryOptions { LocalDirectoryPath = "C:/a", AccountName = "acct", ContainerName = "repo-a" });
         manager.TouchOrAdd(new RepositoryOptions { LocalDirectoryPath = "C:/b", AccountName = "acct", ContainerName = "repo-b" });
@@ -121,9 +125,14 @@ public class RecentRepositoryManagerTests
         settings.SaveCalls.ShouldBe(0);
     }
 
-    private static Func<DateTime> CreateClock(params DateTime[] values)
+    private sealed class SequencedTimeProvider(params DateTimeOffset[] values) : TimeProvider
     {
-        var index = 0;
-        return () => values[Math.Min(index++, values.Length - 1)];
+        private readonly DateTimeOffset[] values = values;
+        private int index;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return values[Math.Min(index++, values.Length - 1)];
+        }
     }
 }

--- a/src/Arius.Explorer.Tests/Settings/RepositoryOptionsTests.cs
+++ b/src/Arius.Explorer.Tests/Settings/RepositoryOptionsTests.cs
@@ -1,0 +1,43 @@
+using Arius.Explorer.Settings;
+using Arius.Explorer.Shared.Extensions;
+
+namespace Arius.Explorer.Tests.Settings;
+
+public class RepositoryOptionsTests
+{
+    [Test]
+    public void AccountKeyAndPassphrase_WhenProtectedValuesAreEmpty_ReturnEmptyStrings()
+    {
+        var repository = new RepositoryOptions();
+
+        repository.AccountKey.ShouldBe(string.Empty);
+        repository.Passphrase.ShouldBe(string.Empty);
+    }
+
+    [Test]
+    public void AccountKeyAndPassphrase_WhenProtectedValuesRoundTrip_ReturnOriginalValues()
+    {
+        var repository = new RepositoryOptions
+        {
+            AccountKeyProtected = "secret-key".Protect(),
+            PassphraseProtected = "secret-pass".Protect(),
+        };
+
+        repository.AccountKey.ShouldBe("secret-key");
+        repository.Passphrase.ShouldBe("secret-pass");
+    }
+
+    [Test]
+    public void ToString_FormatsRepositoryIdentity()
+    {
+        var repository = new RepositoryOptions
+        {
+            LocalDirectoryPath = "C:/data",
+            AccountName = "account",
+            ContainerName = "container",
+        };
+
+        repository.ToString().ShouldContain("account:container");
+        repository.ToString().ShouldContain("data");
+    }
+}

--- a/src/Arius.Explorer.Tests/Shared/Converters/BytesToReadableSizeConverterTests.cs
+++ b/src/Arius.Explorer.Tests/Shared/Converters/BytesToReadableSizeConverterTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Globalization;
+using Arius.Explorer.Shared.Converters;
+
+namespace Arius.Explorer.Tests.Shared.Converters;
+
+public class BytesToReadableSizeConverterTests
+{
+    private static readonly BytesToReadableSizeConverter Converter = new();
+
+    [Test]
+    public void Convert_WhenValueIsLong_ReturnsReadableSize()
+    {
+        var result = Converter.Convert(1536L, typeof(string), null!, CultureInfo.InvariantCulture);
+
+        result.ShouldBeOfType<string>();
+        ((string)result).ShouldContain("KB");
+    }
+
+    [Test]
+    public void Convert_WhenValueIsNotLong_ReturnsNull()
+    {
+        var result = Converter.Convert("1536", typeof(string), null!, CultureInfo.InvariantCulture);
+
+        result.ShouldBeNull();
+    }
+
+    [Test]
+    public void ConvertBack_AlwaysThrows()
+    {
+        Should.Throw<NotImplementedException>(() => Converter.ConvertBack("1.5 KB", typeof(long), null!, CultureInfo.InvariantCulture));
+    }
+}

--- a/src/Arius.Explorer.Tests/Shared/Extensions/DataProtectionExtensionsTests.cs
+++ b/src/Arius.Explorer.Tests/Shared/Extensions/DataProtectionExtensionsTests.cs
@@ -1,0 +1,32 @@
+using Arius.Explorer.Shared.Extensions;
+
+namespace Arius.Explorer.Tests.Shared.Extensions;
+
+public class DataProtectionExtensionsTests
+{
+    [Test]
+    public void ProtectAndUnprotect_WhenTextIsEmpty_ReturnEmptyString()
+    {
+        string.Empty.Protect().ShouldBe(string.Empty);
+        string.Empty.Unprotect().ShouldBe(string.Empty);
+    }
+
+    [Test]
+    public void Unprotect_WhenValueIsNotBase64_ReturnsOriginalValue()
+    {
+        const string plainText = "not-base64";
+
+        plainText.Unprotect().ShouldBe(plainText);
+    }
+
+    [Test]
+    public void ProtectAndUnprotect_RoundTripPlainText()
+    {
+        const string plainText = "secret-value";
+
+        var protectedValue = plainText.Protect();
+
+        protectedValue.ShouldNotBeNull();
+        protectedValue.Unprotect().ShouldBe(plainText);
+    }
+}

--- a/src/Arius.Explorer.Tests/Usings.cs
+++ b/src/Arius.Explorer.Tests/Usings.cs
@@ -1,1 +1,2 @@
 global using Shouldly;
+global using Arius.Explorer.Tests.Settings;

--- a/src/Arius.Explorer/ChooseRepository/ChooseRepositoryViewModel.cs
+++ b/src/Arius.Explorer/ChooseRepository/ChooseRepositoryViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -14,6 +13,7 @@ using Arius.Explorer.Shared.Extensions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mediator;
+using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 using Unit = System.Reactive.Unit;
 
@@ -22,6 +22,7 @@ namespace Arius.Explorer.ChooseRepository;
 public partial class ChooseRepositoryViewModel : ObservableObject, IDisposable
 {
     private readonly IMediator              mediator;
+    private readonly ILogger<ChooseRepositoryViewModel> logger;
     private readonly Subject<Unit>          credentialsChangedSubject = new();
     private readonly IDisposable            debounceSubscription;
     private readonly TimeSpan               debounceTimeSpan;
@@ -32,9 +33,11 @@ public partial class ChooseRepositoryViewModel : ObservableObject, IDisposable
 
     public ChooseRepositoryViewModel(
         IMediator              mediator,
+        ILogger<ChooseRepositoryViewModel> logger,
         TimeSpan?              debounceTimeSpan = null)
     {
-        this.mediator = mediator;
+        this.mediator          = mediator;
+        this.logger            = logger;
         this.debounceTimeSpan  = debounceTimeSpan ?? TimeSpan.FromMilliseconds(500);
         synchronizationContext = SynchronizationContext.Current ?? new SynchronizationContext();
 
@@ -159,11 +162,11 @@ public partial class ChooseRepositoryViewModel : ObservableObject, IDisposable
         }
         catch (OperationCanceledException)
         {
-            Trace.TraceInformation("Container loading was cancelled because credentials changed.");
+            logger.LogDebug("Container loading was cancelled because credentials changed.");
         }
         catch (Exception ex)
         {
-            Trace.TraceError($"Failed to load container names: {ex}");
+            logger.LogError(ex, "Failed to load container names.");
             synchronizationContext.Post(_ =>
             {
                 StorageAccountError = true;
@@ -239,7 +242,7 @@ public partial class ChooseRepositoryViewModel : ObservableObject, IDisposable
         }
         catch (Exception ex)
         {
-            Trace.TraceError($"Failed to prepare the selected repository: {ex}");
+            logger.LogError(ex, "Failed to prepare the selected repository.");
         }
         finally
         {

--- a/src/Arius.Explorer/ChooseRepository/ChooseRepositoryViewModel.cs
+++ b/src/Arius.Explorer/ChooseRepository/ChooseRepositoryViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -158,10 +159,11 @@ public partial class ChooseRepositoryViewModel : ObservableObject, IDisposable
         }
         catch (OperationCanceledException)
         {
-            // Cancellation is expected when new credentials are entered; do not flag as error
+            Trace.TraceInformation("Container loading was cancelled because credentials changed.");
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Trace.TraceError($"Failed to load container names: {ex}");
             synchronizationContext.Post(_ =>
             {
                 StorageAccountError = true;
@@ -235,9 +237,9 @@ public partial class ChooseRepositoryViewModel : ObservableObject, IDisposable
                 window.Close();
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // TODO: Handle error - show message to user
+            Trace.TraceError($"Failed to prepare the selected repository: {ex}");
         }
         finally
         {

--- a/src/Arius.Explorer/RepositoryExplorer/RepositoryExplorerViewModel.cs
+++ b/src/Arius.Explorer/RepositoryExplorer/RepositoryExplorerViewModel.cs
@@ -23,6 +23,9 @@ namespace Arius.Explorer.RepositoryExplorer;
 
 public partial class RepositoryExplorerViewModel : ObservableObject
 {
+    public static Func<string, string, MessageBoxButton, MessageBoxImage, MessageBoxResult> ShowMessageBox { get; set; } =
+        static (message, caption, button, image) => MessageBox.Show(message, caption, button, image);
+
     private readonly IApplicationSettings                 settings;
     private readonly IRecentRepositoryManager             recentRepositoryManager;
     private readonly IDialogService                       dialogService;
@@ -241,7 +244,7 @@ public partial class RepositoryExplorerViewModel : ObservableObject
         catch (Exception e)
         {
             logger.LogError(e, "Error loading node content");
-            MessageBox.Show(
+            ShowMessageBox(
                 $"Failed to load repository content: {e.Message}\n\nPlease check your repository options (Account Name, Account Key, Container Name, and Passphrase).",
                 "Error Loading Repository",
                 MessageBoxButton.OK,
@@ -408,7 +411,7 @@ public partial class RepositoryExplorerViewModel : ObservableObject
         msg.AppendLine();
         msg.AppendLine("Proceed?");
 
-        if (MessageBox.Show(msg.ToString(), App.Name, MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.No)
+        if (ShowMessageBox(msg.ToString(), App.Name, MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.No)
             return;
 
         if (repositorySession.Mediator is null)
@@ -445,7 +448,7 @@ public partial class RepositoryExplorerViewModel : ObservableObject
         catch (Exception ex)
         {
             // Handle error (optionally show message)
-            MessageBox.Show($"Restore failed: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            ShowMessageBox($"Restore failed: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
         }
         finally
         {

--- a/src/Arius.Explorer/RepositoryExplorer/RepositoryExplorerViewModel.cs
+++ b/src/Arius.Explorer/RepositoryExplorer/RepositoryExplorerViewModel.cs
@@ -240,6 +240,7 @@ public partial class RepositoryExplorerViewModel : ObservableObject
         }
         catch (OperationCanceledException)
         {
+            logger.LogDebug("Node content load was cancelled.");
         }
         catch (Exception e)
         {
@@ -291,6 +292,7 @@ public partial class RepositoryExplorerViewModel : ObservableObject
         }
         catch (OperationCanceledException)
         {
+            logger.LogDebug("Hydration status load was cancelled for {Prefix}", node.Prefix);
         }
         catch (Exception ex)
         {

--- a/src/Arius.Explorer/Settings/ApplicationSettings.cs
+++ b/src/Arius.Explorer/Settings/ApplicationSettings.cs
@@ -73,10 +73,12 @@ public interface IRecentRepositoryManager
 public sealed class RecentRepositoryManager : IRecentRepositoryManager
 {
     private readonly IApplicationSettings settings;
+    private readonly Func<DateTime> now;
 
-    public RecentRepositoryManager(IApplicationSettings settings)
+    public RecentRepositoryManager(IApplicationSettings settings, Func<DateTime>? now = null)
     {
         this.settings = settings;
+        this.now = now ?? (() => DateTime.UtcNow);
     }
 
     public IReadOnlyList<RepositoryOptions> GetAll() =>
@@ -97,18 +99,18 @@ public sealed class RecentRepositoryManager : IRecentRepositoryManager
             string.Equals(a.AccountName,        b.AccountName,        StringComparison.OrdinalIgnoreCase);
 
         var existing = settings.RecentRepositories.FirstOrDefault(r => EqualRepositoryOptions(r, repo));
-        var now = DateTime.UtcNow;
+        var openedAt = now();
 
         if (existing is null)
         {
-            repo.LastOpened = now;
+            repo.LastOpened = openedAt;
             settings.RecentRepositories.Add(repo);
         }
         else
         {
             existing.AccountKeyProtected = repo.AccountKeyProtected;
             existing.PassphraseProtected = repo.PassphraseProtected;
-            existing.LastOpened          = now;
+            existing.LastOpened          = openedAt;
             // do not update key properties
             //existing.LocalDirectoryPath  = repo.LocalDirectoryPath;
             //existing.ContainerName       = repo.ContainerName;

--- a/src/Arius.Explorer/Settings/ApplicationSettings.cs
+++ b/src/Arius.Explorer/Settings/ApplicationSettings.cs
@@ -73,12 +73,12 @@ public interface IRecentRepositoryManager
 public sealed class RecentRepositoryManager : IRecentRepositoryManager
 {
     private readonly IApplicationSettings settings;
-    private readonly Func<DateTime> now;
+    private readonly TimeProvider timeProvider;
 
-    public RecentRepositoryManager(IApplicationSettings settings, Func<DateTime>? now = null)
+    public RecentRepositoryManager(IApplicationSettings settings, TimeProvider? timeProvider = null)
     {
         this.settings = settings;
-        this.now = now ?? (() => DateTime.UtcNow);
+        this.timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public IReadOnlyList<RepositoryOptions> GetAll() =>
@@ -99,7 +99,7 @@ public sealed class RecentRepositoryManager : IRecentRepositoryManager
             string.Equals(a.AccountName,        b.AccountName,        StringComparison.OrdinalIgnoreCase);
 
         var existing = settings.RecentRepositories.FirstOrDefault(r => EqualRepositoryOptions(r, repo));
-        var openedAt = now();
+        var openedAt = timeProvider.GetUtcNow().UtcDateTime;
 
         if (existing is null)
         {


### PR DESCRIPTION
## Summary
- fix and expand the Arius.Explorer test suite, including the open-repository command case, repository/session coverage, view model coverage, and Explorer coverage reporting
- add a filtered Explorer coverage settings file and document the TUnit coverage workflow in README.md and AGENTS.md
- remove Explorer-specific slopwatch findings by replacing timing-based waits with deterministic/event-driven test helpers and making cancellation/error handling explicit

## Verification
- dotnet test --project src/Arius.Explorer.Tests/Arius.Explorer.Tests.csproj
- dotnet test --project src/Arius.Explorer.Tests/Arius.Explorer.Tests.csproj --coverage --coverage-settings src/Arius.Explorer.Tests/coverage.settings.xml --coverage-output-format cobertura --coverage-output coverage.filtered.cobertura.xml --results-directory artifacts/TestResults/Arius.Explorer.Tests
- slopwatch analyze -d . --fail-on warning --no-baseline

## Notes
- filtered Arius.Explorer coverage is 84.1% line coverage / 73.8% branch coverage
- slopwatch findings remaining after this branch are outside Arius.Explorer and its test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Injectable message-box delegate for dialog/confirmation flows
  * Configurable clock injection for deterministic time behavior

* **Bug Fixes**
  * Improved exception logging and diagnostic messages for repository/credential flows
  * Enhanced cancellation logging for background loading operations

* **Tests**
  * Large expansion of unit tests across view models, session management, settings, converters, and data protection

* **Chores**
  * Added static-analysis baseline and example suppression config; updated test project guidance and deps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->