### PR TITLE
ci(docs): enable GitHub Pages from the deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,5 +51,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # Enable Pages (build_type=workflow) on first run, so deploy-pages stops
+      # 404ing when Pages was never turned on in repo settings. Idempotent.
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Why

The docs publish CI [failed on master](https://github.com/woutervanranst/Arius7/actions/runs/27874518339) right after #116 merged. The **build job passed**; only **deploy** failed:

```
Error: Failed to create deployment (status: 404) … Ensure GitHub Pages has been enabled
```

GitHub Pages had never been turned on for the repo (it was the one-time `Settings → Pages → Source: GitHub Actions` step), so `actions/deploy-pages` had no Pages site to deploy to.

## Fix

Add `actions/configure-pages@v5` with `enablement: true` as the first step of the deploy job. It enables Pages with `build_type=workflow` on the first run (idempotent afterward), using the job's existing `pages: write` permission — so **no manual Settings toggle is needed** and deploy stops 404ing.

Merging this triggers the `docs` workflow on `master` (the path filter includes `.github/workflows/docs.yml`), which will enable Pages and publish to **https://woutervanranst.github.io/Arius7/**.

> Alternative if you'd rather not merge: enable Pages manually (`Settings → Pages → Source: GitHub Actions`) and re-run the failed run — that also fixes it permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation deployment reliability by ensuring the deployment workflow is properly configured on first run, preventing potential deployment failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->