### PR TITLE
docs: add development guide + restore reference tables (audit follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,69 +118,7 @@ Pass `-k` on the command line, set `ARIUS_KEY` environment variable, authenticat
 
 ## Development
 
-### Test Suite Architecture
-
-| Test project | Purpose | Requires real Azure credentials | Uses Azurite |
-|-------|-------------|-------------------------------|--------------|
-| `src/Arius.Core.Tests` | Fast unit and feature-level tests for core archive, restore, list, snapshot, chunk, and tree behavior without a real storage emulator. | N | N |
-| `src/Arius.AzureBlob.Tests` | Tests the Azure Blob adapter and Azure-specific storage boundary behavior in isolation. | N | N |
-| `src/Arius.Cli.Tests` | Tests command-line parsing, option wiring, and CLI-facing behavior. | N | N |
-| `src/Arius.Architecture.Tests` | Enforces repository structure and architectural boundaries. | N | N |
-| `src/Arius.Explorer.Tests` | Windows-only tests for the Explorer application. | N | N |
-| `src/Arius.Integration.Tests` | Verifies Arius pipelines and shared services against an emulator-backed blob repository, including archive, restore, list, chunk-index, filetree, and crash-recovery paths. | N | Y |
-| `src/Arius.E2E.Tests` | End-to-end Arius behavior coverage across representative archive and restore scenarios, with Azurite for shared coverage and live Azure for opt-in real-service coverage. | Y | Y |
-
-`src/Arius.Tests.Shared` is not a test project. It contains reusable test infrastructure shared by the integration and E2E suites.
-
-Azurite-backed integration and E2E tests report as skipped when Docker is unavailable, so the test report shows that the local emulator coverage was intentionally not run.
-
-#### Setup
-
-All test suites refer the same set of [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) and refer the same set of environment variables. To set up:
-
-```bash
-dotnet user-secrets set "ARIUS_E2E_ACCOUNT" <name> --project src/Arius.E2E.Tests
-dotnet user-secrets set "ARIUS_E2E_KEY"     <key>  --project src/Arius.E2E.Tests
-```
-### End-to-End Tests
-
-`src/Arius.E2E.Tests/` contains the actual end-to-end Arius coverage.
-
-- `RepresentativeArchiveRestoreTests.cs` runs one canonical representative workflow on Azurite and, when credentials are available, live Azure.
-- The representative workflow exercises one evolving archive history instead of isolated one-off scenarios.
-- The canonical workflow covers incremental archive, warm and cold restore, previous-version restore, no-op re-archive, `--no-pointers`, `--remove-local`, conflict handling, and archive-tier pending-versus-ready behavior when the backend supports it.
-- No-op archive runs preserve the current latest snapshot when nothing changed, so snapshot history represents repository state changes rather than repeated command invocations.
-- The synthetic representative repository size is controlled by one explicit constant in `SyntheticRepositoryDefinitionFactory` so development can keep the workflow smaller and tune it upward deliberately later.
-- `E2ETests.cs` keeps the live Azure credential sanity check plus narrow hot-tier pointer-file and large-file probes that the representative workflow does not cover directly.
-
-Azurite-backed tests are discovered on every runner and skip at runtime when Docker is unavailable.
-Live Azure coverage is opt-in and reuses the same canonical representative workflow when credentials are available.
-
-### Mutation Testing
-
-Stryker.NET is configured for local mutation testing of `Arius.Core`.
-
-Install the tool once:
-
-```bash
-dotnet tool install --global dotnet-stryker
-```
-
-Run the Core mutation test pass from the repository root:
-
-```bash
-dotnet stryker --config-file stryker-config.json
-```
-
-### Benchmarks
-
-Run the representative Azurite workflow benchmark with:
-
-```bash
-dotnet run -c Release --project src/Arius.Benchmarks
-```
-
-The benchmark runs the canonical representative workflow with BenchmarkDotNet. Raw BenchmarkDotNet output is written under `src/Arius.Benchmarks/raw/`, and each run appends one line to `src/Arius.Benchmarks/benchmark-tail.log` for autoresearch-style tailing.
+Building, running each host locally, and the full test-suite architecture (unit · integration · E2E · mutation · benchmarks) are covered in the **[Development guide](docs/guide/development.md)**.
 
 ## Blob Storage Structure
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -180,9 +180,15 @@ and [snapshot](core/shared/snapshot.md) (the epoch/coordination model).
 `restore` and `ls` are read-only consumers: they never call `ValidateAsync`,
 `FlushAsync`, `CreateAsync`, or `AddEntry`, and neither creates a blob container.
 Because `FileTreeService.ReadAsync` always writes to the disk cache on a miss, caches
-warm organically across runs (an `archive` warms `ls` and `restore`; same-machine
-re-archive hits the fast-path epoch match with no remote listing). Per-service detail
-is under [Core / Shared](core/shared/chunk-index.md).
+warm organically across runs. Per-service detail is under [Core / Shared](core/shared/chunk-index.md).
+
+| Sequence | Effect |
+|---|---|
+| archive → ls | `ls` finds all tree blobs already cached |
+| archive → restore | restore finds all tree blobs already cached |
+| ls → restore | restore benefits from `ls`'s cache population |
+| archive → archive (same machine) | fast-path epoch match; no remote listing |
+| archive (machine A) → archive (machine B) | one `ListAsync(filetrees/)` prefetch on mismatch, then full cache rebuild |
 
 ---
 

--- a/docs/design/core/shared/filetree.md
+++ b/docs/design/core/shared/filetree.md
@@ -34,6 +34,31 @@ A node's identity is the SHA-256 of its canonical serialized plaintext (`FileTre
 
 The file-entry grammar is byte-identical between staged and persisted nodes; the directory line differs only in *what the first field means* — a final child `FileTreeHash` (persisted) vs. a staging directory id (staged). That shared grammar is why one serializer parses both formats, via two named entry points: `ParsePersistedNodeEntryLine` and `ParseStagedNodeEntryLine`.
 
+### Layout and key types
+
+Repository-local roots come from `RepositoryLocalStatePaths`; filetree-specific path helpers from `FileTreePaths`.
+
+| Location | Owner | Purpose |
+|---|---|---|
+| `~/.arius/{account}-{container}/filetrees/.staging/` | `FileTreeStagingSession` + `FileTreeStagingWriter` | Per-run staging graph; one file per staged directory id. |
+| `~/.arius/{account}-{container}/filetrees/.staging.lock` | `FileTreeStagingSession` | Local mutual exclusion — prevents two local archive runs sharing one staging area. |
+| `~/.arius/{account}-{container}/filetrees/{fileTreeHash}` | `FileTreeService` | Final plaintext disk cache of one immutable node. Zero-byte files are remote-existence markers. |
+| `filetrees/{fileTreeHash}` (blob storage) | `FileTreeService` | Persisted filetree blob: canonical plaintext, zstd-compressed, then optionally encrypted. |
+| `~/.arius/{account}-{container}/snapshots/{timestamp}` | `SnapshotService` | Latest local snapshot cache, read by `ValidateAsync` to decide whether local filetree knowledge is trustworthy. |
+
+| Type | Responsibility |
+|---|---|
+| `FileTreeStagingSession` | Owns `.staging/` lifetime and `.staging.lock`; clears stale staging; one local staging session per repository cache. |
+| `FileTreeStagingWriter` | Converts canonical relative file paths into append-only staged node files (ancestor directory lines + leaf file lines). |
+| `FileTreeEntry` | Base type for entries inside a filetree node. |
+| `FileEntry` | Final file leaf: `Name`, `ContentHash`, `Created`, `Modified`. |
+| `DirectoryEntry` | Final persisted child-directory edge: `Name` + child `FileTreeHash`. |
+| `StagedDirectoryEntry` | Staging-only child edge: `Name` + child staging directory id (used before child hashes are known). |
+| `FileTreeSerializer` | Canonical text (de)serialization for filetree nodes; parses persisted and staged lines into the right subtype. |
+| `FileTreeBuilder` | Reads staged nodes, validates duplicates, recursively builds child subtrees, serializes, computes `FileTreeHash`, publishes finished nodes to the upload channel. |
+| `FileTreeService` | Validates local knowledge of remote filetrees, answers `ExistsInRemote`, uploads nodes, writes the disk cache, reads persisted nodes back. |
+| `SnapshotService` | Publishes the commit point — records the root `FileTreeHash` after all referenced filetrees are stored. |
+
 ### Staging → build → upload pipeline
 
 A filetree is **not** built incrementally as files are hashed. During archive, file entries are appended to flat per-directory staging files; only at the end of the run does `FileTreeBuilder` fold those into immutable Merkle nodes and upload them. This decouples build cost from total file count and keeps the durable commit (the snapshot) last. See [ADR-0006](../../../decisions/adr-0006-build-filetrees-from-hashed-directory-staging.md).

--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -1,0 +1,113 @@
+# Development
+
+How to build, run, and test Arius locally. This is the contributor *how-to*; for **why** the test suite is shaped the way it is (the representative workflow, fixture boundaries, the coverage floor), see [Testing](../design/cross-cutting/testing.md). For using or deploying the built artifacts, see the other [guides](cli.md) and the [README](https://github.com/woutervanranst/Arius7).
+
+## Prerequisites
+
+- **.NET SDK 10** — the projects target `net10.0` (Explorer: `net10.0-windows`).
+- **Node 22** — for the Angular web app (`src/Arius.Web`).
+- **Docker** — optional; only needed to run the Azurite-backed integration and E2E tests locally.
+
+## The solution
+
+`Arius.slnx` holds the .NET projects (`Arius.Core`, `Arius.AzureBlob`, `Arius.Cli`, `Arius.Api`, `Arius.Explorer`, the test projects, and the benchmarks). `src/Arius.Web` (Angular) is a **Node** project, is **not** part of `Arius.slnx`, and is built with npm — its bundle is served by `Arius.Api`.
+
+```bash
+dotnet build        # builds the whole solution
+```
+
+Build the *full* solution after changing a shared `Arius.Core` record or interface — `Arius.Cli`, `Arius.Api`, `Arius.Explorer`, and the test projects all consume Core.
+
+## Running each host locally
+
+### CLI
+
+```bash
+dotnet run --project src/Arius.Cli -- <verb> ...
+```
+
+See the [CLI guide](cli.md) for the verbs and options.
+
+### Web app (API + Angular SPA)
+
+The web UI is the Angular SPA served by `Arius.Api` over REST (`/api`) and SignalR (`/hubs/arius`). In development, run the two halves separately:
+
+```bash
+# 1. start the API (from the repo root)
+dotnet run --project src/Arius.Api          # http://localhost:5080
+
+# 2. start the web dev server
+cd src/Arius.Web
+npm install
+npm start                                   # http://localhost:4200
+```
+
+`proxy.conf.json` forwards `/api` and `/hubs` (WebSocket) to the API, so the SPA is same-origin in dev. Dev state lands under `src/Arius.Api/.appstate/` (gitignored). Full web dev / Docker / Playwright detail is in [`src/Arius.Web/README.md`](https://github.com/woutervanranst/Arius7/blob/master/src/Arius.Web/README.md); to run the packaged single container, see [Deployment](deployment.md).
+
+### Explorer (Windows)
+
+```bash
+dotnet run --project src/Arius.Explorer      # Windows only (WPF, net10.0-windows)
+```
+
+See the [Explorer guide](explorer.md).
+
+## Tests
+
+| Test project | Purpose | Real Azure | Azurite |
+|---|---|:---:|:---:|
+| `src/Arius.Core.Tests` | Fast unit and feature-level tests for archive, restore, list, snapshot, chunk, and tree behavior without a storage emulator. | N | N |
+| `src/Arius.AzureBlob.Tests` | The Azure Blob adapter and Azure-specific storage boundary, in isolation. | N | N |
+| `src/Arius.Cli.Tests` | Command-line parsing, option wiring, and CLI-facing behavior. | N | N |
+| `src/Arius.Architecture.Tests` | Enforces repository structure and architectural boundaries. | N | N |
+| `src/Arius.Explorer.Tests` | Windows-only tests for the Explorer application. | N | N |
+| `src/Arius.Integration.Tests` | Pipelines and shared services against an emulator-backed repository (archive, restore, list, chunk-index, filetree, crash recovery). | N | Y |
+| `src/Arius.E2E.Tests` | End-to-end behavior across representative archive/restore scenarios — Azurite for shared coverage, live Azure for opt-in real-service coverage. | Y | Y |
+
+`src/Arius.Tests.Shared` is **not** a test project — it is the reusable test infrastructure shared by the integration and E2E suites (see [Testing](../design/cross-cutting/testing.md)). Azurite-backed integration and E2E tests **skip at runtime** when Docker is unavailable, reported as skipped rather than filtered out.
+
+### Running tests
+
+```bash
+dotnet test                                   # whole solution
+dotnet test --project src/Arius.Core.Tests    # one project
+```
+
+- These projects use **TUnit** on the Microsoft Testing Platform. Filter by class/test with `--treenode-filter "/*/*/<ClassName>/*"` — the standard `--filter` flag silently runs zero tests.
+- Web unit tests: `cd src/Arius.Web && ng test` (Karma/Jasmine). Web end-to-end (Playwright) tests are documented in [`src/Arius.Web/README.md`](https://github.com/woutervanranst/Arius7/blob/master/src/Arius.Web/README.md).
+
+### Setup (credentials for live tests)
+
+The test suites read the same user secrets / environment variables. To set up:
+
+```bash
+dotnet user-secrets set "ARIUS_E2E_ACCOUNT" <name> --project src/Arius.E2E.Tests
+dotnet user-secrets set "ARIUS_E2E_KEY"     <key>  --project src/Arius.E2E.Tests
+```
+
+### End-to-end tests
+
+`src/Arius.E2E.Tests/` contains the actual end-to-end coverage:
+
+- `RepresentativeArchiveRestoreTests.cs` runs one canonical representative workflow on Azurite and, when credentials are available, live Azure.
+- The workflow exercises one evolving archive history (not isolated one-off scenarios): incremental archive, warm and cold restore, previous-version restore, no-op re-archive, `--no-pointers`, `--remove-local`, conflict handling, and archive-tier pending-versus-ready behavior when the backend supports it.
+- No-op archive runs preserve the current latest snapshot, so snapshot history reflects repository state changes, not repeated invocations.
+- The synthetic repository size is one explicit constant in `SyntheticRepositoryDefinitionFactory` — tune it upward deliberately.
+- `E2ETests.cs` keeps the live Azure credential sanity check plus narrow hot-tier pointer-file and large-file probes the representative workflow does not cover directly.
+
+### Mutation testing
+
+Stryker.NET is configured for local mutation testing of `Arius.Core`:
+
+```bash
+dotnet tool install --global dotnet-stryker     # once
+dotnet stryker --config-file stryker-config.json
+```
+
+### Benchmarks
+
+```bash
+dotnet run -c Release --project src/Arius.Benchmarks
+```
+
+Runs the canonical representative workflow with BenchmarkDotNet. Raw output goes under `src/Arius.Benchmarks/raw/`, and each run appends a line to `src/Arius.Benchmarks/benchmark-tail.log`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - guide/web-ui.md
       - guide/explorer.md
       - guide/deployment.md
+      - guide/development.md
   - Design:
       - design/README.md
       - Core — Features:


### PR DESCRIPTION
## Why

You worried information was lost when the docs were consolidated (commit `b0c7fb45` deleted the 19 openspec specs, `cache.md`, `filetrees.md` after lifting them). I ran a coverage audit — recovered every deleted source from git (`b0c7fb45^`) and diffed it against the new docs.

**Verdict: no durable design intent was lost.** Most flagged "gaps" were already covered (e.g. `ContainerNamesQuery` in `queries.md`; `ProgressState` thread-safety + the `TrackedFile`/`TrackedTar` state machines in `hosts/cli.md`; restore cost-model gotchas in `restore-command.md`; cross-machine slow-path in `snapshot.md`/`filetree.md`). Three genuine items remained; this PR fixes them.

## What changed

- **New `docs/guide/development.md`** — the contributor *how to build / run / test locally* guide. This was the one item with **no docs-site home** (it lived only in the root README, `src/Arius.Web/README.md`, and `AGENTS.md`). It gives the web dev-server commands (`dotnet run --project src/Arius.Api` :5080, `npm start` :4200) a discoverable home and cross-links `design/cross-cutting/testing.md` for the test *architecture* (this guide = how-to-run; testing.md = why). Added to the site nav.
- **Trimmed the root `README.md` "Development" section** to a one-line pointer to the new guide (no duplication; README stays user-facing).
- **Restored two scannable reference tables** whose content had become prose-only: the cross-run cache **warm-up matrix** (incl. the machine‑A→B row) in `design/README.md`, and the filetree **layout + key-types** tables in `filetree.md` — refreshed to current names (`RepositoryLocalStatePaths`, zstd).

## Deliberately *not* done
Mechanical implementation detail (per-event `FileSize` sources, full CLI option catalogs, progress-callback wiring, event-throttling constants) — that belongs in the code per the project's "don't restate mechanics" principle; the audit confirmed no *intent* was lost there. (Security/threat-model page: deferred.)

## Verification
`mkdocs build --strict` → exit 0, **0 warnings**; the dev-server commands render on the site, the machine‑A→B warm-up row and the filetree tables are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)